### PR TITLE
fix "publish" method with empty "replyTo" subject

### DIFF
--- a/nats_client.tcl
+++ b/nats_client.tcl
@@ -257,7 +257,7 @@ oo::class create ::nats::connection {
         set replySubj ""
         set header ""
         if {[llength $args] == 1} {
-            set replySubj $args
+            set replySubj [lindex $args 0]
         } else {
             foreach {opt val} $args {
                 switch -- $opt {


### PR DESCRIPTION
Hi,

I have encountered following behavior:
When calling "publish" with explicit empty "reply" subject (objectName publish subject message ?reply?), for example:
`objectName publish "some.example.subject" "msg1" ""`

Than nats-cli tool showed:
`[#1] Received on "some.example.subject" with reply "{}"`

Which is wrong (it should be without "with reply" part).
So here is little fix :)

Best regards