### PR TITLE
feat: add -check_connection option for publish, add last_flush variable

### DIFF
--- a/API.md
+++ b/API.md
@@ -74,12 +74,11 @@ If you have received a message with a header, but have *not* used `-dictmsg true
 Note that the JetStream API **always** returns messages as dicts.
 
 ## Public variables
-The connection object exposes 3 "public" read-only variables:
+The connection object exposes 2 "public" read-only variables:
 - `last_error` - used to deliver asynchronous errors, e.g. if the network fails. It is a dict with 2 keys similar to the arguments for `throw`:
   - code: error code 
   - errorMessage: error message
-- `status` - connection status, one of `$nats::status_closed`, `$nats::status_connecting`, `$nats::status_connected` or `$nats::status_reconnecting`,
-- `last_flush` - time in milliseconds when last successful flush was done.
+- `status` - connection status, one of `$nats::status_closed`, `$nats::status_connecting`, `$nats::status_connected` or `$nats::status_reconnecting`.
 
 You can set up traces on these variables to get notified e.g. when a connection status changes.
 
@@ -107,6 +106,7 @@ The **configure** method accepts the following options. Make sure to set them *b
 | -token | string | | Default authentication token|
 | -secure | boolean | false | If secure=true, connection will fail if a server can't provide a TLS connection |
 | -check_subjects | boolean | true | Enable client-side checking of subjects when publishing or subscribing |
+| -check_connection | boolean | true | Check connection with server while publishing/subscribing (default) and throw error if connection is not established |
 | -dictmsg | boolean | false | Return messages from `subscribe` and `request` as dicts by default |
 | -? | | | Provides interactive help with all options|
 
@@ -137,12 +137,11 @@ objectName publish subject message ?reply?
 ```
 and if you need extra options:
 ```Tcl
-objectName publish subject message ?-header header? ?-reply reply? ?-check_connection check_connection?
+objectName publish subject message ?-header header? ?-reply reply?
 ```
 Publishes a message to the specified subject. See the NATS [documentation](https://docs.nats.io/nats-concepts/subjects) for more details about subjects and wildcards. The client will check subject's validity before sending. Allowed characters are Latin-1 characters, digits, dot, dash and underscore. <br/>
 `message` is sent as is, and it can be a binary string. If you specify a `reply` subject, a responder will know where to send a reply. You can use the `inbox` method to generate a transient [subject name](https://docs.nats.io/developing-with-nats/sending/replyto) starting with _INBOX. However, using asynchronous requests might accomplish the same task in an easier manner - see below.<br/>
 When using NATS server version 2.2 and later, you can provide a `header` with the message. 
-Providing boolean `check_connection` set to false (default is true) can add messages to buffor even if connection with server has not been established - they will be send after successful connection. So it does not throw error if there is no connection and because of that - it also does not chceck if server supports headers or its `max_payload` size.
 
 ### objectName subscribe subject ?-queue queueGroup? ?-callback cmdPrefix? ?-max_msgs maxMsgs? ?-dictmsg dictmsg?
 Subscribes to a subject (possibly with wildcards) and returns a subscription ID. Whenever a message arrives, the command prefix will be invoked from the event loop with 3 additional arguments: `subject`, `message` and `replyTo` (might be empty). If you use the [-queue option](https://docs.nats.io/developing-with-nats/receiving/queues), only one subscriber in a given queueGroup will receive each message (useful for load balancing). When given `-max_msgs`, the client will automatically unsubscribe after `maxMsgs` messages have been received.<br />

--- a/jet_stream.tcl
+++ b/jet_stream.tcl
@@ -453,7 +453,7 @@ oo::class create ::nats::jet_stream {
         try {
             set responseDict [::json::json2dict [dict get $response data]]
 
-            if {[string match "*stream_msg_get_response" [dict get $responseDict type]]} {
+            if {[dict exists $responseDict type] && [string match "*stream_msg_get_response" [dict get $responseDict type]]} {
                 if {[dict exists $responseDict message data]} {
                     dict set responseDict message data [binary decode base64 [dict get $responseDict message data]]
                 }

--- a/nats_client.tcl
+++ b/nats_client.tcl
@@ -41,6 +41,7 @@ set ::nats::option_syntax {
     { token.arg ""                      "Default authentication token"}
     { secure.boolean false              "If secure=true, connection will fail if a server can't provide a TLS connection"}
     { check_subjects.boolean true       "Enable client-side checking of subjects when publishing or subscribing"}
+    { check_connection.boolean true     "Check connection with server while publishing/subscribing (default) and throw error if connection is not established"}
     { dictmsg.boolean false             "Return messages from subscribe&request as dicts by default" }
 }
 
@@ -50,7 +51,7 @@ oo::class create ::nats::connection {
              subjectRegex outBuffer randomChan requestsInboxPrefix jetStream pong logger
     
     # "public" variables, so that users can set up traces if needed
-    variable status last_error last_flush
+    variable status last_error
 
     constructor { { conn_name "" } } {
         set status $nats::status_closed
@@ -94,7 +95,6 @@ oo::class create ::nats::connection {
         # all outgoing messages are put in this list before being flushed to the socket,
         # so that even when we are reconnecting, messages can still be sent
         set outBuffer [list]
-        set last_flush ""
         set randomChan [tcl::chan::random [tcl::randomseed]] ;# generate inboxes
         set requestsInboxPrefix ""
         set jetStream ""
@@ -257,7 +257,6 @@ oo::class create ::nats::connection {
     method publish {subject message args} {
         set replySubj ""
         set header ""
-        set checkConnection 1
         if {[llength $args] == 1} {
             set replySubj [lindex $args 0]
         } else {
@@ -269,9 +268,6 @@ oo::class create ::nats::connection {
                     -reply {
                         set replySubj $val
                     }
-                    -check_connection {
-                        set checkConnection $val
-                    }
                     default {
                         throw {NATS ErrInvalidArg} "Unknown option $opt"
                     }
@@ -280,7 +276,7 @@ oo::class create ::nats::connection {
         }
         
         set msgLen [string length $message]
-        if {$checkConnection || $status == $nats::status_connected || $status == $nats::status_reconnecting} {
+        if {$config(check_connection) || $status == $nats::status_connected || $status == $nats::status_reconnecting} {
             my CheckConnection
             if {$msgLen > $serverInfo(max_payload)} {
                 throw {NATS ErrMaxPayload} "Maximum size of NATS message is $serverInfo(max_payload)"
@@ -315,8 +311,10 @@ oo::class create ::nats::connection {
         return
     }
     
-    method subscribe {subject args } {
-        my CheckConnection
+    method subscribe {subject args} {
+        if {$config(check_connection)} {
+            my CheckConnection
+        }
         set queue ""
         set callback ""
         set maxMsgs 0 ;# unlimited by default
@@ -368,19 +366,19 @@ oo::class create ::nats::connection {
         set subscriptions($subID) [dict create subj $subject queue $queue cmd $callback maxMsgs $maxMsgs recMsgs 0 dictmsg $dictmsg]
         
         #the format is SUB <subject> [queue group] <sid>
-        if {$status != $nats::status_reconnecting} {
-            # it will be sent anyway when we reconnect
-            lappend outBuffer "SUB $subject $queue $subID"
-            if {$maxMsgs > 0} {
-                lappend outBuffer "UNSUB $subID $maxMsgs"
-            }
-            my ScheduleFlush
+        lappend outBuffer "SUB $subject $queue $subID"
+        if {$maxMsgs > 0} {
+            lappend outBuffer "UNSUB $subID $maxMsgs"
         }
+
+        my ScheduleFlush
         return $subID
     }
     
     method unsubscribe {subID args} {
-        my CheckConnection
+        if {$config(check_connection)} {
+            my CheckConnection
+        }
         set maxMsgs 0 ;# unlimited by default
         foreach {opt val} $args {
             switch -- $opt {
@@ -409,11 +407,9 @@ oo::class create ::nats::connection {
             dict set subscriptions($subID) maxMsgs $maxMsgs
             set data "UNSUB $subID $maxMsgs"
         }
-        if {$status != $nats::status_reconnecting} {
-            # it will be sent anyway when we reconnect
-            lappend outBuffer $data
-            my ScheduleFlush
-        }
+        lappend outBuffer $data
+
+        my ScheduleFlush
         return
     }
     
@@ -650,7 +646,6 @@ oo::class create ::nats::connection {
                 puts -nonewline $sock $msg
             }
             set outBuffer [list]
-            set last_flush [clock milliseconds]
         }
         close $sock ;# all buffered input is discarded, all buffered output is flushed
         set sock ""
@@ -705,7 +700,6 @@ oo::class create ::nats::connection {
         }
         # do NOT clear the buffer unless we had a successful flush!
         set outBuffer [list]
-        set last_flush [clock milliseconds]
     }
     
     method CoroVwait {var} {


### PR DESCRIPTION
Hi, 
I have implemented two minor changes - check what you feel about them :)

1. add last_flush variable to connection object: we have use case, where we publish some messages (e.g. every interval) and connection is lost and in this moment our process is restarted - this way we don't know if all messages were flushed to NATS server or not (well, probably not). In that case we would want to re-publish those messages that weren't send, but we don't know which one were published and which not. Using `last_flush` would allow to know what messages have really been send (comparing simple timestamp or setting trace). This way we can store messages to be re-published on disk.
2. add -check_connection to publish method - setting it to false would allow to call this method even if connection was not established yet - so in code it would look nicer, without need to store messages somewhere and publish them after connection. They would just be added to buffor and send when server is available.