### PR TITLE
New NATS server (available from 2.7.4) settings for js consume

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,13 @@ proc consumeAsyncCallback {timedOut msg} {
     # do sth...
     $jet_stream ack $msg
 }
+
+# It is possible to provide all agruments supported by NATS server for consuming:
+#-expires
+#-idle_heartbeat
+#-no_wait
+#-batch_size
+
 # consume a batch of 100 messages within the next 10 seconds
 # the callback will be invoked once for each message
 $jet_stream consume my_stream my_consumer -callback consumeAsyncCallback -timeout 10000 -batch_size 100

--- a/nats_client.tcl
+++ b/nats_client.tcl
@@ -444,6 +444,9 @@ oo::class create ::nats::connection {
                         throw {NATS ErrInvalidArg} "Invalid max_msgs $maxMsgs"
                     }
                 }
+                -custom_reqID {
+                    set custom_reqID $val
+                }
                 default {
                     throw {NATS ErrInvalidArg} "Unknown option $opt"
                 }
@@ -454,7 +457,11 @@ oo::class create ::nats::connection {
             throw {NATS ErrInvalidArg} "-max_msgs>1 can be used only in async request"
         }
         
-        set reqID [incr counters(request)]
+        if {[info exists custom_reqID]} {
+            set reqID $custom_reqID
+        } else {
+            set reqID [incr counters(request)]
+        }
         
         if {$requestsInboxPrefix eq ""} {
             set requestsInboxPrefix [my inbox]
@@ -596,6 +603,12 @@ oo::class create ::nats::connection {
             # no-responders is equivalent to timedOut=1
             set timedOut 1
         }
+
+        # handle the nats timeout e.q. for pull consumers
+        if {[nats::get_default $in_hdr Status 0] == 408} {
+            set timedOut 1
+        }
+
         if {![dict get $requests($reqID) isDictMsg]} {
             set msg [dict get $msg data]
         }
@@ -1258,7 +1271,7 @@ proc ::nats::get_default {dict_val key def} {
 # so I end up with the same message logged twice. Let's suppress stderr altogether
 proc ::nats::tls_callback {args} { }
 
-package provide nats 1.0
+package provide NatsTest 1.0
 
 # Let me respectfully remind you:
 # Birth and death are of supreme importance.

--- a/nats_client.tcl
+++ b/nats_client.tcl
@@ -1271,7 +1271,7 @@ proc ::nats::get_default {dict_val key def} {
 # so I end up with the same message logged twice. Let's suppress stderr altogether
 proc ::nats::tls_callback {args} { }
 
-package provide NatsTest 1.0
+package provide nats 1.0
 
 # Let me respectfully remind you:
 # Birth and death are of supreme importance.


### PR DESCRIPTION
Hi,

I added parameter handling to the consume method. The 'expires' option in particular is useful in my implementation because it specifies a timeout on the NATS server side. For this reason, I also added support for returning the timeout if such information is received from NATS.
Additionally, I've added the optional ability to set a custom reqID. This is useful when sequentially calling the consume method with a specific timeout. In the case of a broken connection to a NATS server, the first message received after the connection returned could get lost, due to the fact that it went back to the previous reqID (since by default the reqID is incremented), using a custom (and in my case fixed) identifier improves this case.

Best regards
