### PR TITLE
fix: add nocomplain to unset subscription

### DIFF
--- a/nats_client.tcl
+++ b/nats_client.tcl
@@ -507,7 +507,7 @@ oo::class create ::nats::connection {
         unset requests($reqID)
         if {[dict get $sync_req timedOut]} {
             if {$subID ne ""} {
-                unset subscriptions($subID)
+                unset -nocomplain subscriptions($subID)
             }
             throw {NATS ErrTimeout} "Request to $subject timed out"
         }


### PR DESCRIPTION
Add nocomplain to unset subscription in request method
due to the possibility of calling the request method twice
because of the timeout and expire argument

Scope: nats_client