### PR TITLE
further work on JS management

### DIFF
--- a/CoreAPI.md
+++ b/CoreAPI.md
@@ -24,25 +24,12 @@ package require nats
 [*objectName* **destroy**](#objectName-destroy)
 
 [*objectName* **jet_stream**](#objectName-jet_stream) <br/>
-[*jetStreamObject* **add_stream** *stream ?-timeout ms? ?-callback cmdPrefix? ?-subjects subjects? ?-retention retention? ?-max_consumers max_consumers? ?-max_msgs max_msgs? ?-max_bytes max_bytes? ?-max_age max_age? ?-max_msgs_per_subject max_msgs_per_subject? ?-max_msg_size max_msg_size? ?-discard discard? ?-storage storage? ?-num_replicas num_replicas? ?-duplicate_window duplicate_window? ?-sealed sealed? ?-deny_delete deny_delete? ?-deny_purge deny_purge? ?-allow_rollup_hdrs allow_rollup_hdrs?*](#jetstreamobject-add_stream-stream--timeout-ms--callback-cmdprefix--subjects-subjects--retention-retention--max_consumers-max_consumers--max_msgs-max_msgs--max_bytes-max_bytes--max_age-max_age--max_msgs_per_subject-max_msgs_per_subject--max_msg_size-max_msg_size--discard-discard--storage-storage--num_replicas-num_replicas--duplicate_window-duplicate_window--sealed-sealed--deny_delete-deny_delete--deny_purge-deny_purge--allow_rollup_hdrs-allow_rollup_hdrs) <br/>
-[*jetStreamObject* **delete_stream** *stream ?-timeout ms? ?-callback cmdPrefix?*](#jetstreamobject-delete_stream-stream--timeout-ms--callback-cmdprefix) <br/>
-[*jetStreamObject* **purge_stream** *stream ?-timeout ms? ?-callback cmdPrefix?*](#jetstreamobject-purge_stream-stream--timeout-ms--callback-cmdprefix) <br/>
-[*jetStreamObject* **stream_names** *?-timeout ms? ?-callback cmdPrefix?*](#jetstreamobject-stream_names--timeout-ms--callback-cmdprefix) <br/>
-[*jetStreamObject* **stream_info** *?stream? ?-timeout ms? ?-callback cmdPrefix?*](#jetstreamobject-stream_info-stream--timeout-ms--callback-cmdprefix) <br/>
-[*jetStreamObject* **stream_msg_get** *stream ?-last_by_subj subject? ?-seq sequence? ?-timeout ms? ?-callback cmdPrefix?*](#jetstreamobject-stream_msg_get-stream--last_by_subj-subject--seq-sequence--timeout-ms--callback-cmdprefix) <br/>
-[*jetStreamObject* **stream_msg_delete** *stream -seq sequence ?-timeout ms? ?-callback cmdPrefix?*](#jetstreamobject-stream_msg_delete-stream--seq-sequence--timeout-ms--callback-cmdprefix) <br/>
-[*jetStreamObject* **consume** *stream consumer ?-timeout ms? ?-callback cmdPrefix? ?-batch_size batch_size?*](#jetStreamObject-consume-stream-consumer--timeout-ms--callback-cmdPrefix--batch_size-batch_size) <br/>
-[*jetStreamObject* **ack** *message*](#jetStreamObject-ack-message) <br/>
-[*jetStreamObject* **publish** *subject message ?-timeout ms? ?-callback cmdPrefix? ?-header header?*](#jetStreamObject-publish-subject-message--timeout-ms--callback-cmdPrefix--header-header) <br/>
-
 
 ## Callbacks
 All callbacks are treated as command prefixes (like [trace](https://www.tcl.tk/man/tcl8.6/TclCmd/trace.htm) callbacks), so in addition to a command itself they may include user-supplied arguments. They are invoked from the event loop as follows:
 ### Core NATS: <br/>
 **subscriptionCallback** *subject message replyTo*<br/>
 **asyncRequestCallback** *timedOut message* <br/>
-### JetStream: <br/>
-**publishCallback** *timedOut pubAck error* <br/>
 
 ## Message headers
 When using NATS server version 2.2 and later, you can publish and receive messages with [headers](https://pkg.go.dev/github.com/nats-io/nats.go?utm_source=godoc#Header). Please, keep in mind that:
@@ -192,42 +179,6 @@ TclOO destructor. It calls `disconnect` and then destroys the object.
 
 ### objectName jet_stream
 Returns `jetStreamObject` TclOO object to work with [JetStream](https://docs.nats.io/jetstream/jetstream).
-
-### jetStreamObject add_stream stream ?-timeout ms? ?-callback cmdPrefix? ?-subjects subjects? ?-retention retention? ?-max_consumers max_consumers? ?-max_msgs max_msgs? ?-max_bytes max_bytes? ?-max_age max_age? ?-max_msgs_per_subject max_msgs_per_subject? ?-max_msg_size max_msg_size? ?-discard discard? ?-storage storage? ?-num_replicas num_replicas? ?-duplicate_window duplicate_window? ?-sealed sealed? ?-deny_delete deny_delete? ?-deny_purge deny_purge? ?-allow_rollup_hdrs allow_rollup_hdrs?
-Add stream `stream` with spedified properties. `subjects` properties is a list of subjects, `duplicate_window` and `max_age` are duration which should be given in milliseconds unit.
-
-### jetStreamObject delete_stream stream ?-timeout ms? ?-callback cmdPrefix?
-Delete stream `stream`.
-
-### jetStreamObject purge_stream stream ?-timeout ms? ?-callback cmdPrefix?
-Purge stream `stream`.
-
-### jetStreamObject stream_names ?-timeout ms? ?-callback cmdPrefix?
-Get available stream names existing on server.
-
-### jetStreamObject stream_info ?stream? ?-timeout ms? ?-callback cmdPrefix?
-Get info about stream `stream` or if `stream` is empty - get information about all streams.
-
-### jetStreamObject stream_msg_get stream ?-last_by_subj subject? ?-seq sequence? ?-timeout ms? ?-callback cmdPrefix?
-Get message from stream `stream` by given `subject` or `sequence`.
-
-### jetStreamObject stream_msg_delete stream -seq sequence ?-timeout ms? ?-callback cmdPrefix?
-Delete message from stream `stream` with given `sequence`.
-
-### jetStreamObject consume stream consumer ?-timeout ms? ?-callback cmdPrefix? ?-batch_size batch_size?
-Consume a message or `batch_size` number of messages from a [consumer](https://docs.nats.io/jetstream/concepts/consumers) defined on a [stream](https://docs.nats.io/jetstream/concepts/streams). Similarly to the `request` method:
-- If no callback is given, the request is synchronous and blocks in a (coroutine-aware) `vwait` until a response is received. The response message is always returned as a dict. If no response arrives within `timeout`, it raises `ErrTimeout`.
-- If a callback is given, the call returns immediately, and when a reply is received or a timeout fires, the command prefix will be invoked from the event loop with 2 additional arguments: `timedOut` (true, if the request timed out) and `message` as a dict (same as for `asyncRequestCallback`). If your consumer is configured for explicit acknowledgement, pass the received `message` to the `ack` method as shown below.
-
-Default `batch_size` is 1. `batch_size`>1 is possible only in the async version, i.e. `cmdPrefix` becomes mandatory.
-
-### jetStreamObject ack message
-Acknowledge the received `message` from the *jetStreamObject* **consume** method. If the message is not acknowledged, it is redelivered on next `consume` (depending on NATS server settings).
-
-### jetStreamObject publish subject message ?-timeout ms? ?-callback cmdPrefix? ?-header header?
-Publish `message` to a [stream](https://docs.nats.io/jetstream/concepts/streams) on the specified `subject`. `timeout` and `cmdPrefix` have similar meaning as in `request` method. If no stream exists on specified `subject`, the call will raise `ErrNoResponders`.
-- In synchronous version the method waits for acknowledgement and returns a response from server as a dict containing `stream`, `seq` and optionally `duplicate` keys. If NATS server returned an error, it raises `ErrJSResponse`.
-- In asynchronous version `cmdPrefix` callback is called with 3 additional arguments: `timedOut` (true, if the request timed out), `pubAck` and `error`. If `error` is not empty, it is a dict containing `code` and `description` JSON keys sent by NATS server, otherwise `pubAck` contains information passed from NATS server as a dict with keys: `stream`, `seq` and optionally `duplicate`.
 
 ## Error handling
 Error codes are similar to those from the nats.go client as much as possible. A few additional error codes provide more information about failed connection attempts to the NATS server: ErrBrokenSocket, ErrTLS, ErrConnectionRefused.

--- a/JsAPI.md
+++ b/JsAPI.md
@@ -1,0 +1,67 @@
+# JetStream
+
+JetStream functionality of NATS can be accessed using the `nats` package by creating a `jetStream` TclOO object. Do not create it directly - instead, call the `jet_stream` method of your `nats::connection` after you've connected to a NATS server.
+
+## Synopsis
+
+[*objectName* **jet_stream**](#objectName-jet_stream) <br/>
+[*jetStreamObject* **add_stream** *stream ?-timeout ms? ?-callback cmdPrefix? ?-subjects subjects? ?-retention retention? ?-max_consumers max_consumers? ?-max_msgs max_msgs? ?-max_bytes max_bytes? ?-max_age max_age? ?-max_msgs_per_subject max_msgs_per_subject? ?-max_msg_size max_msg_size? ?-discard discard? ?-storage storage? ?-num_replicas num_replicas? ?-duplicate_window duplicate_window? ?-sealed sealed? ?-deny_delete deny_delete? ?-deny_purge deny_purge? ?-allow_rollup_hdrs allow_rollup_hdrs?*](#jetstreamobject-add_stream-stream--timeout-ms--callback-cmdprefix--subjects-subjects--retention-retention--max_consumers-max_consumers--max_msgs-max_msgs--max_bytes-max_bytes--max_age-max_age--max_msgs_per_subject-max_msgs_per_subject--max_msg_size-max_msg_size--discard-discard--storage-storage--num_replicas-num_replicas--duplicate_window-duplicate_window--sealed-sealed--deny_delete-deny_delete--deny_purge-deny_purge--allow_rollup_hdrs-allow_rollup_hdrs) <br/>
+[*jetStreamObject* **delete_stream** *stream ?-timeout ms? ?-callback cmdPrefix?*](#jetstreamobject-delete_stream-stream--timeout-ms--callback-cmdprefix) <br/>
+[*jetStreamObject* **purge_stream** *stream ?-timeout ms? ?-callback cmdPrefix?*](#jetstreamobject-purge_stream-stream--timeout-ms--callback-cmdprefix) <br/>
+[*jetStreamObject* **stream_names** *?-timeout ms? ?-callback cmdPrefix?*](#jetstreamobject-stream_names--timeout-ms--callback-cmdprefix) <br/>
+[*jetStreamObject* **stream_info** *?stream? ?-timeout ms? ?-callback cmdPrefix?*](#jetstreamobject-stream_info-stream--timeout-ms--callback-cmdprefix) <br/>
+[*jetStreamObject* **stream_msg_get** *stream ?-last_by_subj subject? ?-seq sequence? ?-timeout ms? ?-callback cmdPrefix?*](#jetstreamobject-stream_msg_get-stream--last_by_subj-subject--seq-sequence--timeout-ms--callback-cmdprefix) <br/>
+[*jetStreamObject* **stream_msg_delete** *stream -seq sequence ?-timeout ms? ?-callback cmdPrefix?*](#jetstreamobject-stream_msg_delete-stream--seq-sequence--timeout-ms--callback-cmdprefix) <br/>
+[*jetStreamObject* **consume** *stream consumer ?-timeout ms? ?-callback cmdPrefix? ?-batch_size batch_size?*](#jetStreamObject-consume-stream-consumer--timeout-ms--callback-cmdPrefix--batch_size-batch_size) <br/>
+[*jetStreamObject* **ack** *message*](#jetStreamObject-ack-message) <br/>
+[*jetStreamObject* **publish** *subject message ?-timeout ms? ?-callback cmdPrefix? ?-header header?*](#jetStreamObject-publish-subject-message--timeout-ms--callback-cmdPrefix--header-header) <br/>
+
+## Callbacks
+All callbacks are treated as command prefixes (like [trace](https://www.tcl.tk/man/tcl8.6/TclCmd/trace.htm) callbacks), so in addition to a command itself they may include user-supplied arguments. They are invoked from the event loop as follows:
+
+### JetStream: <br/>
+**publishCallback** *timedOut pubAck error* <br/>
+
+## Description
+
+### objectName jet_stream
+Returns `jetStreamObject` TclOO object to work with [JetStream](https://docs.nats.io/jetstream/jetstream).
+
+### jetStreamObject add_stream stream ?-timeout ms? ?-callback cmdPrefix? ?-subjects subjects? ?-retention retention? ?-max_consumers max_consumers? ?-max_msgs max_msgs? ?-max_bytes max_bytes? ?-max_age max_age? ?-max_msgs_per_subject max_msgs_per_subject? ?-max_msg_size max_msg_size? ?-discard discard? ?-storage storage? ?-num_replicas num_replicas? ?-duplicate_window duplicate_window? ?-sealed sealed? ?-deny_delete deny_delete? ?-deny_purge deny_purge? ?-allow_rollup_hdrs allow_rollup_hdrs?
+Add stream `stream` with spedified properties. `subjects` properties is a list of subjects, `duplicate_window` and `max_age` are duration which should be given in milliseconds unit.
+
+### jetStreamObject delete_stream stream ?-timeout ms? ?-callback cmdPrefix?
+Delete stream `stream`.
+
+### jetStreamObject purge_stream stream ?-timeout ms? ?-callback cmdPrefix?
+Purge stream `stream`.
+
+### jetStreamObject stream_names ?-timeout ms? ?-callback cmdPrefix?
+Get available stream names existing on server.
+
+### jetStreamObject stream_info ?stream? ?-timeout ms? ?-callback cmdPrefix?
+Get info about stream `stream` or if `stream` is empty - get information about all streams.
+
+### jetStreamObject stream_msg_get stream ?-last_by_subj subject? ?-seq sequence? ?-timeout ms? ?-callback cmdPrefix?
+Get message from stream `stream` by given `subject` or `sequence`.
+
+### jetStreamObject stream_msg_delete stream -seq sequence ?-timeout ms? ?-callback cmdPrefix?
+Delete message from stream `stream` with given `sequence`.
+
+### jetStreamObject consume stream consumer ?-timeout ms? ?-callback cmdPrefix? ?-batch_size batch_size?
+Consume a message or `batch_size` number of messages from a [consumer](https://docs.nats.io/jetstream/concepts/consumers) defined on a [stream](https://docs.nats.io/jetstream/concepts/streams). Similarly to the `request` method:
+- If no callback is given, the request is synchronous and blocks in a (coroutine-aware) `vwait` until a response is received. The response message is always returned as a dict. If no response arrives within `timeout`, it raises `ErrTimeout`.
+- If a callback is given, the call returns immediately, and when a reply is received or a timeout fires, the command prefix will be invoked from the event loop with 2 additional arguments: `timedOut` (true, if the request timed out) and `message` as a dict (same as for `asyncRequestCallback`). If your consumer is configured for explicit acknowledgement, pass the received `message` to the `ack` method as shown below.
+
+Default `batch_size` is 1. `batch_size`>1 is possible only in the async version, i.e. `cmdPrefix` becomes mandatory.
+
+### jetStreamObject ack message
+Acknowledge the received `message` from the *jetStreamObject* **consume** method. If the message is not acknowledged, it is redelivered on next `consume` (depending on NATS server settings).
+
+### jetStreamObject publish subject message ?-timeout ms? ?-callback cmdPrefix? ?-header header?
+Publish `message` to a [stream](https://docs.nats.io/jetstream/concepts/streams) on the specified `subject`. `timeout` and `cmdPrefix` have similar meaning as in `request` method. If no stream exists on specified `subject`, the call will raise `ErrNoResponders`.
+- In synchronous version the method waits for acknowledgement and returns a response from server as a dict containing `stream`, `seq` and optionally `duplicate` keys. If NATS server returned an error, it raises `ErrJSResponse`.
+- In asynchronous version `cmdPrefix` callback is called with 3 additional arguments: `timedOut` (true, if the request timed out), `pubAck` and `error`. If `error` is not empty, it is a dict containing `code` and `description` JSON keys sent by NATS server, otherwise `pubAck` contains information passed from NATS server as a dict with keys: `stream`, `seq` and optionally `duplicate`.
+
+## Error handling
+TBW

--- a/jet_stream.tcl
+++ b/jet_stream.tcl
@@ -39,10 +39,7 @@ oo::class create ::nats::jet_stream {
                     set msg [::nats::_json_write_object "seq" $val]
                 }
                 default {
-                    if {$opt ni [list -callback]} {
-                        throw {NATS ErrInvalidArg} "Unknown option $opt"
-                    }
-                    dict set common_arguments $opt $val
+                    throw {NATS ErrInvalidArg} "Unknown option $opt"
                 }
             }
         }
@@ -67,10 +64,7 @@ oo::class create ::nats::jet_stream {
                     set msg [::nats::_json_write_object "seq" $val]
                 }
                 default {
-                    if {$opt ni [list -callback]} {
-                        throw {NATS ErrInvalidArg} "Unknown option $opt"
-                    }
-                    dict set common_arguments $opt $val
+                    throw {NATS ErrInvalidArg} "Unknown option $opt"
                 }
             }
         }
@@ -248,15 +242,7 @@ oo::class create ::nats::jet_stream {
                     }
                     dict set config_dict ack_policy $val
                 }                
-                -callback {
-                    # receive status of adding consumer on callback proc
-                    set callback [mymethod PublishCallback $val]
-                }
                 default {
-                    if {$opt in [list -callback]} {
-                        dict set common_arguments $opt $val
-                        continue
-                    }
                     set opt_raw [string range $opt 1 end] ;# remove flag
                     # duration args - provided in milliseconds should be formatted to nanoseconds 
                     if {$opt_raw in [list "idle_heartbeat" "ack_wait"]} {
@@ -351,6 +337,7 @@ oo::class create ::nats::jet_stream {
 
     # nats schema info --yaml io.nats.jetstream.api.v1.stream_create_request
     # nats schema info --yaml io.nats.jetstream.api.v1.stream_create_response
+    # TODO update_stream?
     method add_stream {stream args} {
         if {![${conn}::my CheckSubject $stream]} {
             throw {NATS ErrInvalidArg} "Invalid stream name $stream"
@@ -371,10 +358,6 @@ oo::class create ::nats::jet_stream {
                     dict set config_dict subjects [::json::write array {*}[lmap subject $val {::json::write string $subject}]]
                 }
                 default {
-                    if {$opt in [list -callback ]} {
-                        dict set common_arguments $opt $val
-                        continue
-                    }
                     set opt_raw [string range $opt 1 end] ;# remove flag
                     # duration args - provided in milliseconds should be formatted to nanoseconds 
                     if {$opt_raw in [list "duplicate_window" "max_age"]} {

--- a/nats_client.tcl
+++ b/nats_client.tcl
@@ -471,11 +471,11 @@ oo::class create ::nats::connection {
         throw {NATS ErrTimeout} "PING timeout"
     }
 
-    method jet_stream {} {
-        if {$jetStream eq ""} {
-            set jetStream [::nats::jet_stream new [self]]
+    method jet_stream {args} {
+        nats::_parse_args $args {
+            timeout timeout 5000
         }
-        return $jetStream
+        return [nats::jet_stream new [self] $timeout]
     }
     
     method inbox {} {

--- a/tests/jet_stream.test
+++ b/tests/jet_stream.test
@@ -25,7 +25,7 @@ test jet_stream-1.1 "Publish and sync consume" -setup {
     $conn connect
 } -body {
     $conn publish test.1 "msg 1"
-    set jet_stream [$conn jet_stream]
+    set jet_stream [$conn jet_stream -timeout 1000]
     set msg [$jet_stream consume $stream_name $consumer_name]
     assert {[dict get $msg subject] eq "test.1"} 1
     dict get $msg data
@@ -103,18 +103,18 @@ test jet_stream-5.2 "Publish message to JetStream async" -body {
 }
 
 test jet_stream-5.3 "Publish message to JetStream sync - no such stream" -body {
-    $jet_stream publish not.exists "not.exists" -timeout 1000
+    $jet_stream publish not.exists "not.exists"
 } -result "No responders available for request" -errorCode {NATS ErrNoResponders} 
 
 test jet_stream-5.4 "Publish message to JetStream async - no such stream" -body {
     duration {
-        $jet_stream publish not.exists "not.exists" -timeout 500 -callback [lambda {timedOut pubAck pubError} {
+        $jet_stream publish not.exists "not.exists" -callback [lambda {timedOut pubAck pubError} {
             set ::timedOut $timedOut
         }]
     } elapsed
     assert {$elapsed < 50}
     duration {
-        wait_for ::timedOut 1000
+        wait_for ::timedOut 2000
     } elapsed
     puts "jet_stream-8 elapsed: $elapsed"
     set timedOut

--- a/tests/jet_stream_mgmt.test
+++ b/tests/jet_stream_mgmt.test
@@ -4,7 +4,9 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and  limitations under the License.
 
 # Test summary:
-# -
+# - actions on a stream: create, get info, get names, purge, delete
+# - actions on a pull consumer: create, get info, get names, delete
+# - actions on a message: get, delete
 
 startNats NATS_JS -js
 set conn [nats::connection new]
@@ -68,7 +70,7 @@ set exp_consumer_config [dict create \
 
 #TODO try -idle_heartbeat 60000000000, -flow_control false  for pull consumer - should fail
 
-test js_mgmt-4 "Add a pull consumer" -body {
+test js_mgmt-4.1 "Add a pull consumer" -body {
     $js add_consumer MY_STREAM {*}$exp_consumer_config
     set actual_config [dict get [json::json2dict [execNatsCmd consumer info -j MY_STREAM PULL_CONSUMER]] config]
     
@@ -80,6 +82,44 @@ test js_mgmt-4 "Add a pull consumer" -body {
     dict unset exp opt_start_seq
     assert {[dict_in $exp $actual_config]}
 }
+
+test js_mgmt-4.2 "Get consumer info" -body {
+    set cons_info [$js consumer_info MY_STREAM PULL_CONSUMER]
+    dict get $cons_info name
+} -result "PULL_CONSUMER"
+
+test js_mgmt-4.3 "Get consumer names" -body {
+    set result [$js consumer_names MY_STREAM]
+    dict get $result consumers  ;# TODO flatten the structure
+} -result "PULL_CONSUMER"
+
+test js_mgmt-4.4 "Delete a consumer" -body {
+    set response [$js delete_consumer MY_STREAM PULL_CONSUMER]
+    dict get $response success
+} -result true
+
+test js_mgmt-5.1 "Get a message directly from a stream" -body {
+    $conn publish test.1 "msg 1"
+    set response [$js stream_msg_get MY_STREAM -last_by_subj test.1]
+    set seq [dict get $response message seq]
+    # puts $response  ;# includes also seq, time (ISO)
+    dict get $response message data ;# TODO flatten the structure - remove "message"
+} -result "msg 1"
+
+test js_mgmt-5.2 "Delete a message directly from a stream" -body {
+    set response [$js stream_msg_delete MY_STREAM -seq $seq]  ;# if not found, this will throw ErrJSResponse 400
+    dict get $response success
+} -result true
+
+test js_mgmt-6 "Purge a stream" -body {
+    set response [$js purge_stream MY_STREAM]
+    dict get $response success
+} -result true
+
+test js_mgmt-7 "Delete a stream" -body {
+    set response [$js delete_stream MY_STREAM]
+    dict get $response success
+} -result true
 
 
 $conn destroy


### PR DESCRIPTION
- split API.md into CoreAPI and JsAPI
- remove -callback argument from JS mgmt functions;
- move -timeout  to JS constructor
- tests for JS mgmt