### PR TITLE
fix handling closed socket

### DIFF
--- a/nats_client.tcl
+++ b/nats_client.tcl
@@ -1115,13 +1115,13 @@ oo::class create ::nats::connection {
                     my AsyncError ErrBrokenSocket "Server $host:$port [lindex [dict get $errOpts -errorcode] end]" 1
                     return
                 }
+                if {[eof $sock]} {
+                    #set err [chan configure $sock -error] - no point in this, $err will be blank
+                    lassign [my current_server] host port
+                    my AsyncError ErrBrokenSocket "Server $host:$port closed the connection" 1
+                    return
+                }
                 if {$readCount <= 0} {
-                    if {[eof $sock]} { 
-                        #set err [chan configure $sock -error] - no point in this, $err will be blank
-                        lassign [my current_server] host port
-                        my AsyncError ErrBrokenSocket "Server $host:$port closed the connection" 1
-                        return
-                    }
                     if {[chan pending input $sock] > 1024} {
                         # do not let the buffer grow forever if \r\n never arrives
                         # max length of control line in the NATS protocol is 1024 (see MAX_CONTROL_LINE_SIZE in nats.py)


### PR DESCRIPTION
Hi, I recently have encountered some problem with handling closed socket.

I had a lot of processes in my application and some of them have very often received 'eof' from socket (why this happend I'm not sure yet, probably it's something with system resources/connection speed/NATS server termination).
In most cases I have just received `Server xyz closed the connection`, but sometimes I got for example:
`Invalid protocol MS` or something like `Unexpected error: Expected integer, but got "" while executing "incr expMsgLength 2"`.

Both this messages looked like we got only part of message while reading from socket. I have read about `chan gets channelId ?varName?` in the documentation and it says:
```
If an end-of-file occurs while part way through reading a line, the partial line will be returned (or written into varName).
```

So we actually can read part of message, if there was `eof` later, and treat it as a whole causing problem with handling it further. If we move `eof` check above that `if` statement, we will terminate it quicker and do re-connect without unexpected errors.

I have encountered this in old version, but I see that it is probably still here :)

Best regards