### PR TITLE
fix reconnecting after "POSIX ECONNRESET" socket error

### DIFF
--- a/nats_client.tcl
+++ b/nats_client.tcl
@@ -1112,8 +1112,8 @@ oo::class create ::nats::connection {
                 # so I don't need a loop around [chan gets] to read all lines, even if they arrive together
                 try {
                     set readCount [chan gets $sock line]
-                } trap {POSIX ECONNABORTED} {err errOpts} {
-                    # can happen only on Linux
+                } trap {POSIX} {err errOpts} {
+                    # can be ECONNABORTED or ECONNRESET
                     lassign [my current_server] host port
                     my AsyncError ErrBrokenSocket "Server $host:$port [lindex [dict get $errOpts -errorcode] end]" 1
                     return


### PR DESCRIPTION
Hi!

I have recently encountered following error (Windows 10):

```
Unexpected error: error reading "sock0000000002461180": connection reset by peer -errorstack {INNER {invokeStk1 ::tcl::chan::gets sock0000000002461180 line} CALL {my ProcessEvent readable} CALL {::oo::Obj25::my CoroMain}} -errorcode {POSIX ECONNRESET {connection reset by peer}} -errorinfo {error reading "sock0000000002461180": connection reset by peer
    while executing
"chan gets $sock line"
    (class "::nats::connection" method "ProcessEvent" line 40)
    invoked from within
"my ProcessEvent $reason"
    ("try" body line 8)} -errorline 8 -code 1 -level 0
```

As it states "POSIX ECONNRESET" can also be thrown during "chan gets" in "ProcessEvent readable" method. In current state of code, this error is not caught and it propagates to "CoroMain" as "Unexpected error" causing application to stop working, because no reconnect is implemented there.
I have fixed it by trapping all "POSIX" errors during "chan gets", but I think it is worth considering if it wouldn't be even safer to reset connection for any "Unexpected error" or for any "chan gets" errors. I have looked at implementation for "gets" (Tcl_GetsObjCmd which probably is the same as "chan gets") and I think POSIX errors are the only ones that can be thrown in this situation, but I'm not sure.

Kindest regards