### PR TITLE
support for key-value store

### DIFF
--- a/JsAPI.md
+++ b/JsAPI.md
@@ -33,6 +33,8 @@ JetStream functionality of NATS can be accessed by creating the `nats::jet_strea
 [*js* stream_msg_get *stream* ?-last_by_subj *subj*? ?-next_by_subj *subj*? ?-seq *int*?](#js-stream_msg_get-stream--last_by_subj-subj--next_by_subj-subj--seq-int)<br/>
 [*js* stream_msg_delete *stream* -seq *sequence* ?-no_erase *no_erase*?](#js-stream_msg_delete-stream--seq-sequence--no_erase-no_erase)<br/>
 
+[*js* key_value ?-timeout *ms*? ?-check_bucket *enabled*? ?-read_only *enabled*?](#js-key_value--timeout-ms--check_bucket-enabled--read_only-enabled) <br/>
+
 [*js* destroy](#js-destroy)<br/>
 
 ## Description
@@ -57,7 +59,7 @@ Unfortunately, I don't have enough capacity to cover the whole JetStream functio
 
 The implementation can tolerate minor changes in JetStream API. E.g. a publish acknowledgment is returned just as a dict parsed from JSON. So, if in future the JSON schema gets a new field, it will be automatically available in this dict.
 
-If you need other JetStream functions, e.g. the Key/Value Store or Object Store, you can easily implement them yourself using core NATS requests. No need to interact directly with the TCP socket. Of course, PRs are always welcome.
+If you need other JetStream functions, e.g. Object Store, you can easily implement them yourself using core NATS requests. No need to interact directly with the TCP socket. Of course, PRs are always welcome.
 
 ## Notable differences from official NATS clients
 Note that API of official NATS clients (`JetStreamContext`) is designed in a way that allows to create a consumer implicitly with a subscription (e.g. `JetStreamContext.pull_subscribe` in nats.py). I find such design somewhat confusing, so the Tcl API clearly distinguishes between creating a consumer and a subscription.
@@ -165,28 +167,30 @@ Returns a dict with metadata of the message. It is extracted from the reply-to f
 Cancels the asynchronous pull request with the given `reqID`.
 ### js add_stream *stream* ?-option *value*?..
 Create or update a `stream` with configuration specified as option-value pairs. See the [official docs](https://docs.nats.io/nats-concepts/jetstream/streams#configuration) for explanation of these options.
-| Option        | Type   | Default |
-| ------------- |--------|---------|
-| -description  | string |         |
-| -subjects     | list of strings  | (required)|
-| -retention    | one of: limits, interest,<br/> workqueue |limits |
-| -max_consumers  | int |         |
-| -max_msgs  | int |         |
-| -max_bytes  | int |         |
-| -discard  | one of: new, old | old |
-| -max_age  | ms |         |
-| -max_msgs_per_subject  | int |         |
-| -max_msg_size  | int |         |
-| -storage  | one of: memory, file | file |
-| -num_replicas  | int |         |
-| -no_ack  | boolean |         |
-| -duplicate_window  | ms |         |
-| -sealed  | boolean |         |
-| -deny_delete  | boolean |         |
-| -deny_purge  | boolean |         |
-| -allow_rollup_hdrs  | boolean |         |
-| -allow_direct  | boolean |         |
-| -mirror_direct  | boolean |         |
+| Option        | Type   | Default | Info |
+| ------------- |--------|---------|------|
+| -description  | string |         |      |
+| -subjects     | list of strings  | (required)| Is not required if `-mirror` or `-subject` options are present.   |
+| -retention    | one of: limits, interest,<br/> workqueue |limits |    |
+| -max_consumers  | int |         |   |
+| -max_msgs  | int |         |    |
+| -max_bytes  | int |         |   |
+| -discard  | one of: new, old | old |    |
+| -max_age  | ms |         |    |
+| -max_msgs_per_subject  | int |         |    |
+| -max_msg_size  | int |         |    |
+| -storage  | one of: memory, file | file |   |
+| -num_replicas  | int |         |    |
+| -no_ack  | boolean |         |    |
+| -duplicate_window  | ms |         |   |
+| -sealed  | boolean |         |    |
+| -deny_delete  | boolean |         |   |
+| -deny_purge  | boolean |         |    |
+| -allow_rollup_hdrs  | boolean |         |   |
+| -allow_direct  | boolean |         |    |
+| -mirror_direct  | boolean |         |   |
+| -mirror  | dict |         | Should have `name` key (which JetStream to copy from) and can also have `external` key as another dict with `api` key (in order to copy from another domain). For example: `{name js_to_mirror external {api $JS.other_domain.API}}` (`\$JS` is special api prefix).   |
+| -sources  | list of dicts |         | Dicts should be the same as with `-mirror` option.   |
 
 
 Returns a JetStream response as a dict.
@@ -246,6 +250,8 @@ Returns a list of all consumers defined on this stream.
 'Direct Get' a message from stream `stream` by given `subject` or `sequence`. See also [ADR-31](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-31.md).
 ### js stream_msg_delete *stream* -seq *int* ?-no_erase *no_erase*?
 Delete message from `stream` with the given `sequence` number.
+### *js* key_value ?-timeout *ms*? ?-check_bucket *enabled*? ?-read_only *enabled*?
+This 'factory' method creates [keyValueObject](KvAPI.md) to work with Key-Value stores. `-timeout` (default value is get from JS object) is applied to `history` and `keys` requests to Key-Value NATS API. For the rest of requests `timeout` from JS and basic nats connection is used. `-check_bucket` (default true) takes care of checking if bucket exists or is mirror of another bucket, before sending requests to one. If it is disabled and given bucket does not exists than timeout will be fired (or `NoResponders`) instead of throwing a `BucketNotFound` error (check [KvAPI](KvAPI.md#implementation-information) for more information). `-timeout` and `-check_bucket` can be overridden for some functions. `-read_only` (default false) can disable ability to modify buckets and keys.
 ### js destroy
 TclOO destructor. Remember to call it before destroying the parent `nats::connection`.
 

--- a/KvAPI.md
+++ b/KvAPI.md
@@ -1,0 +1,153 @@
+# Key-Value API
+
+Key-Value functionality of NATS can be accessed by creating the `nats::key_value` TclOO object (using jet_stream object). Do not create it directly - instead, call the [key_value](JsAPI.md#js-key_value--timeout-ms--check_bucket-enabled--read_only-enabled) method of your `nats::jet_stream`. You can have multiple KV objects created from the same JetStream, each having its own settings.
+
+## Synopsis
+
+[*kv* get *bucket key* ?-revision *revision*?](#kv-get-bucket-key--revision-revision)<br/>
+[*kv* put *bucket key value* ?-check_bucket *check_bucket*?](#kv-put-bucket-key-value--check_bucket-check_bucket)<br/>
+[*kv* create *bucket key value* ?-check_bucket *check_bucket*?](#kv-create-bucket-key-value--check_bucket-check_bucket)<br/>
+[*kv* update *bucket key revision value* ?-check_bucket *check_bucket*?](#kv-update-bucket-key-revision-value--check_bucket-check_bucket)<br/>
+[*kv* del *bucket* ?*key*? ?-check_bucket *check_bucket*?](#kv-del-bucket-key--check_bucket-check_bucket)<br/>
+[*kv* purge *bucket key* ?-check_bucket *check_bucket*?](#kv-purge-bucket-key--check_bucket-check_bucket)<br/>
+[*kv* revert *bucket key revision* ?-check_bucket *check_bucket*?](#kv-revert-bucket-key-revision--check_bucket-check_bucket)<br/>
+[*kv* history *bucket key* ?-timeout *timeout*? ?--check_bucket-check_bucket *check_bucket*?](#kv-history-bucket-key--timeout-timeout-check_bucket)<br/>
+[*kv* watch *bucket* ?*key*? ?-callback *callback*? ?-include_history *include_history*? ?-updates_only *updates_only*? ?-headers_only *headers_only*? ?-ignore_deletes *ignore_deletes*? ?-idle_heartbeat *idle_heartbeat*? ?-check_bucket *check_bucket*?](#kv-watch-bucket-key--callback-callback--include_history-include_history--updates_only-updates_only--headers_only-headers_only--ignore_deletes-ignore_deletes--idle_heartbeat-idle_heartbeat--check_bucket-check_bucket)<br/>
+[*kv* unwatch *watchId*](#kv-unwatch-watchid)<br/>
+
+[*kv* add *bucket* ?-history *history*? ?-storage *storage*? ?-ttl *ttl*? ?-max_value_size *max_value_size*? ?-max_bucket_size *max_bucket_size*? ?-mirror_name *mirror_name*? ?-mirror_domain *mirror_domain*?](#kv-add-bucket--history-history--storage-storage--ttl-ttl--max_value_size-max_value_size--max_bucket_size-max_bucket_size--mirror_name-mirror_name--mirror_domain-mirror_domain)<br/>
+[*kv* info *bucket*](#kv-info-bucket)<br/>
+[*kv* ls](#kv-ls)<br/>
+[*kv* keys *bucket* ?-timeout *timeout*?](#kv-keys-bucket--timeout-timeout)<br/>
+
+[*kv* destroy](#kv-destroy)<br/>
+
+## Description (from [official documentation](https://docs.nats.io/nats-concepts/jetstream/key-value-store))
+
+JetSteam, the persistence layer of NATS, doesn't just allow for higher qualities of service and features associated with 'streaming', but it also enables some functionalities not found in messaging systems.
+One such feature is the Key/Value store functionality, which allows client applications to create `buckets` and use them as immediately consistent, persistent associative arrays.
+You can use KV buckets to perform the typical operations you would expect from an immediately consistent key/value store:
+- put: associate a value with a key
+- get: retrieve the value associated with a key
+- delete: clear any value associated with a key
+- purge: clear all the values associated with all keys
+- create: associate the value with a key only if there is currently no value associated with that key (i.e. compare to null and set)
+- update: compare and set (aka compare and swap) the value for a key
+- keys: get a copy of all the keys (with a value or operation associated to it)
+
+You can set limits for your buckets, such as:
+- the maximum size of the bucket
+- the maximum size for any single value
+- a TTL: how long the store will keep values for
+
+Finally, you can even do things that typically can not be done with a Key/Value Store:
+- watch: watch for changes happening for a key, which is similar to subscribing (in the publish/subscribe sense) to the key: the watcher receives updates due to put or delete operations on the key pushed to it in real-time as they happen
+- watch all: watch for all the changes happening on all the keys in the bucket
+- history: retrieve a history of the values (and delete operations) associated with each key over time (by default the history of buckets is set to 1, meaning that only the latest value/operation is stored)
+
+## Implementation information
+
+Implementation is based mainly on official [guidelines](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-8.md) and `nats-cli` client. It supports all main methods and work comparably to other clients. It is worth noticing that:
+- `-utf8_convert` option on core nats client is also applicable to all KV operations, so when it is `true` than all incoming/outgoing messages are automatically converted. 
+- `-check_bucket` on a lot of methods can be used to override configuration of KV object (`$js key_value -check_bucket true`). It takes care of checking if bucket exists, before sending requests to one. If it is disabled and given bucket does not exists than in most cases timeout will be fired (or `NoResponders`) instead of throwing a `BucketNotFound` error. It also receives information about kv mirror and depending on that takes care of properly handling api request. So when kv is a mirror and `-check_bucket` is disabled it probably won't work the way it should. Disabling it would mean sending less requests and therefore requests will be quicker, but do it only in certain scenarios: when kv is existing for sure and it is not a mirror. 
+- most of methods checks if `bucket` and `key` names are valid. `bucket` could only contain letters, numbers, `_` and `-`. `key` could also contain `/`, `=` and `.` (but it cannot start or end with `.` and cannot start with `_kv`).
+- KV object can be configured as read-only (`$js key_value -read_only true`). In this mode operations that modify keys or bucket are disabled (this operations will throw `KvReadOnly`).
+- in addition to all core NATS and JetStream errors, the `key_value` methods may throw `KeyNotFound`, `BucketNotFound`, `WrongLastSequence` and `KvReadOnly` errors based on situation,
+- `cross-domain` requests are supported (`domain` is copied from `jet_stream` object) so acting on kv from another domain is possible (see examples),
+- `mirroring` (as well as `cross-domain` mirroring) is supported.
+
+## Entry
+
+Methods returning messages kept under the `key` are returning `entry`, which is a dict consisting of:
+- `value` - value of key,
+- `bucket` - bucket on which this `entry` exists,
+- `key` - key on which this `entry` exists,
+- `operation` - `PUT`, `DEL` or `PURGE`,
+- `revision` - unique number in given `bucket` (`seq` of message in stream),
+- `created` - time when this `entry` has been uploaded (milliseconds).
+
+## Commands
+
+### kv get *bucket key* ?-revision *revision*?
+
+Gets an entry for a `key` from the store `bucket`. Optionally it can retrieve specified revision of given key. `KeyNotFound` can be raised if `key` does not exists, revision does not belong to `key` or when `key` has been deleted or purged.
+
+### kv put *bucket key value* ?-check_bucket *check_bucket*?
+
+Puts a `value` into a `key`.
+
+### kv create *bucket key value* ?-check_bucket *check_bucket*?
+
+Puts a `value` into a `key` only if the `key` does not exists or it's last operation was delete/purge. If `key` already exists than `WrongLastSequence` will be thrown.
+
+### kv update *bucket key revision value* ?-check_bucket *check_bucket*?
+
+Updates a `key` with a new `value` only if the previous `entry` matches the given `revision`. If `revision` does not match than `WrongLastSequence` will be thrown. Useful when updates on key are based on previous values - using `update` (instead of `put`) will make sure no other values were set to key between read and write. 
+
+### kv del *bucket* ?*key*? ?-check_bucket *check_bucket*?
+
+Deletes a `key` or the entire `bucket` if no `key` is supplied (preserves history).
+
+### kv purge *bucket key* ?-check_bucket *check_bucket*?
+
+Deletes a `key` from the `bucket`, clearing history before creating a delete marker.
+
+### kv revert *bucket key revision* ?-check_bucket *check_bucket*?
+
+Reverts a value to a previous `revision` using put. It simply gets `revision` of `key` and puts it again.
+
+### kv history *bucket key* ?-timeout *timeout*? ?-check_bucket *check_bucket*?
+
+Gets the full history for a `key`. In order to do that, under the hood ephemeral consumer is created that gets necessary messages and returns when all required entries has been gathered. 
+`-timeout` can override default configuration.
+
+### kv watch *bucket* ?*key*? ?-callback *callback*? ?-include_history *include_history*? ?-updates_only *updates_only*? ?-headers_only *headers_only*? ?-ignore_deletes *ignore_deletes*? ?-idle_heartbeat *idle_heartbeat*? ?-check_bucket *check_bucket*?
+
+Watch the `bucket` or a specific `key` for updates.
+It takes care of receiving healthcheck (`idle_heartbeat`) from server and re-create consumer if necessary.
+By default current state of keys are being passed to `callback` as well as updates.
+Returns `watchId` which can be used to stop watching for changes.
+
+`watch` can start with following parameters:
+- `callback` - required, callback to be called with new entries/errors,
+- `include_history` - callback will receive all available history (instead of only last entry),
+- `updates_only` - callback will receive only updates, without current state of keys,
+- `headers_only` - entries passed to `callback` will not contain `value`, only headers - it can be useful e.g. to watch for available keys,
+- `ignore_deletes` - `callback` will not be called with `delete` and `purge` operations,
+- `idle_heartbeat` - default 5000 (5s) - specifies healthcheck time for consumer,
+
+`callback` is called with two arguments: `status` and `msg`, where `status` can be one of:
+- `error` - means that there is some problem with watcher - probably server is disconnected or consumer was deleted. More information will be in `msg`,
+- `ok` - previously delivered error no longer exists - healthcheck is passing (instead of `ok` new message can be received - it also means that everything is fine),
+- `end_of_initial_data` - means that initial data (e.g. history) has been delivered and from now on new messages will contain update.
+- empty - new message is being delivered. `msg` will contain new entry.
+
+### kv unwatch *watchId*
+
+Stop watching previously started `watch`.
+
+### kv add *bucket* ?-history *history*? ?-storage *storage*? ?-ttl *ttl*? ?-max_value_size *max_value_size*? ?-max_bucket_size *max_bucket_size*? ?-mirror_name *mirror_name*? ?-mirror_domain *mirror_domain*?
+
+Adds a new KV Store Bucket `bucket`. It can be configured using following parameters:
+- `history` - default `1`, how many messages per key should be kept. By default only last one is preserved,
+- `storage` - default `file`,
+- `ttl` - default `-1`, how long the bucket keeps values for,
+- `max_value_size` - default `-1`, what is max size of message (bytes),
+- `max_bucket_size` - default `-1`, max `bucket` size can be configured.
+- `mirror_name` - creates a mirror of a different bucket,
+- `mirror_domain` - when mirroring find the bucket in a different domain.
+### kv info *bucket*
+
+View the status of a KV store `bucket`.
+Returns dict containing `bucket`, `stream`, `storage`, `history`, `ttl`, `max_value_size`, `max_bucket_size` (and optionally `mirror`) as well as other information: `created` (in milliseconds), `values_stored`, `bytes_stored`, `backing_store` and `store_config`, `store_state` - last two of them contains full configuration of underlying JetStream.
+
+### kv ls
+
+List available buckets.
+
+### kv keys *bucket* ?-timeout *timeout*?
+
+List available keys in a bucket. Similarly to [history](#kv-history-bucket-key--timeout-timeout) it creates ephemeral consumer to achieve that.
+
+### kv destroy
+TclOO destructor. Remember to call it before destroying the parent `nats::jet_stream`.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Feature-wise, the package is comparable to other NATS clients and is inspired by
 
 With this package you can bring the power of the publish/subscribe mechanism to your Tcl and significantly simplify development of distributed applications.
 
-The API reference documentation is split into [Core NATS](CoreAPI.md) and [JetStream](JsAPI.md).
+The API reference documentation is split into [Core NATS](CoreAPI.md), [JetStream](JsAPI.md) and [Key-Value Store](KvAPI.md).
 
 ## Supported platforms
 
@@ -43,8 +43,9 @@ If you are using a "batteries-included" Tcl distribution, like [Magicsplat](http
 - Synchronous and asynchronous requests (optimized: under the hood a single wildcard subscription is used for all requests)
 - Queue groups
 - Gather multiple responses to a request
-- Publishing and consuming messages from JetStream, providing "at least once" or "exactly once" delivery guarantees
+- Publishing and consuming messages from JetStream, providing "at least once" or "exactly once" delivery guarantee
 - Management of JetStream streams and consumers
+- Support for JetStream based Key-Value Stores
 - Standard `configure` method with many options
 - Protected connections using TLS
 - Automatic reconnection in case of network or server failure

--- a/examples/conf/accounts.conf
+++ b/examples/conf/accounts.conf
@@ -1,0 +1,10 @@
+accounts {
+    SYS: {
+        users: [{user: admin, password: admin}]
+    },
+    ACC: {
+        users: [{user: acc, password: acc}],
+        jetstream: enabled
+    }
+}
+system_account: SYS

--- a/examples/conf/hub.conf
+++ b/examples/conf/hub.conf
@@ -1,0 +1,10 @@
+port: 4222
+server_name: hub-server
+jetstream {
+    store_dir="./store_server"
+    domain=hub
+}
+leafnodes {
+    port: 7422
+}
+include ./accounts.conf

--- a/examples/conf/leaf.conf
+++ b/examples/conf/leaf.conf
@@ -1,0 +1,19 @@
+port: 4111
+server_name: leaf-server
+jetstream {
+    store_dir="./store_leaf"
+    domain=leaf
+}
+leafnodes {
+    remotes = [
+        {
+            urls: ["nats://admin:admin@0.0.0.0:7422"]
+            account: "SYS"
+        },
+        {
+            urls: ["nats://acc:acc@0.0.0.0:7422"]
+            account: "ACC"
+        }
+    ]
+}
+include ./accounts.conf

--- a/examples/kv.tcl
+++ b/examples/kv.tcl
@@ -1,0 +1,63 @@
+# EXAMPLE #7: Key-Value Store usage and management
+# remember to start nats-server with -js to enable JetStream and -sd to set the storage directory
+
+package require nats
+set conn [nats::connection new "MyNats"]
+$conn configure -servers nats://localhost:4222
+$conn connect
+set js [$conn jet_stream -timeout 2000]
+set kv [$js key_value]
+
+set bucket MY_KEY_VALUE
+
+##### BASIC OPERATIONS #####
+
+# create a new key-value store named "MY_KEY_VALUE" with history of 10 messages per key
+puts "Creating new bucket named \"$bucket\"..."
+$kv add $bucket -history 10
+
+# put (and delete) some values to "key1" key
+puts "Setting some history of updates on \"key1\" key..."
+$kv put $bucket key1 "hi, it's my FIRST message"
+$kv del $bucket key1 ;# delete last value (only to see it in history) - operation of this entry would be "DEL"
+$kv put $bucket key1 "hi, it's my SECOND message"
+$kv put $bucket key1 "hi, it's my THIRD message"
+
+set current_val [$kv get $bucket key1]
+puts "\nCurrent value for \"key1\" is: \"[dict get $current_val value]\""
+puts "Current entry for \"key1\" is: \"$current_val\""
+
+set history [$kv history $bucket key1]
+puts "\nHistory of \"key1\" is: \"$history\""
+
+try {
+    $kv create $bucket key1 "it won't be set"
+} trap {NATS WrongLastSequence} {} {
+    puts "\n\"create\" will only work if given key does not exists (or last operation was DEL/PURGE)"
+}
+
+try {
+    $kv update $bucket key1 2 "it won't be set"
+} trap {NATS WrongLastSequence} {} {
+    puts "\"update\" will only work if last revision is matching revision passed as argument (last revision is \"4\" but we gave \"2\", so it won't update)"
+}
+
+##### KV INFO #####
+
+set ls [$kv ls]
+puts "\nAvailable buckets are: $ls"
+
+set keys [$kv keys $bucket]
+puts "\nAvailable bucket \"$bucket\" keys are: $keys"
+
+set info [$kv info $bucket]
+puts "\nBucket \"$bucket\" info looks like this: $info"
+
+##### CLEANUP #####
+
+puts "\nRemoving \"$bucket\" bucket and ending program..."
+$kv del $bucket
+
+$kv destroy
+$js destroy
+$conn destroy

--- a/examples/kv_mirror.tcl
+++ b/examples/kv_mirror.tcl
@@ -1,0 +1,75 @@
+# EXAMPLE #9: Key-Value Store mirroring and domains
+
+#### FIRST SETUP TWO SERVERS #####
+# they use different domains in order to show how to use mirroring between domains
+# 1. nats-server -c ./conf/hub.conf
+# 2. nats-server -c ./conf/leaf.conf
+
+package require nats
+
+# connect to hub server
+set conn_hub [nats::connection new "MyNatsToHub"]
+$conn_hub configure -servers nats://localhost:4222 -user acc -password acc
+$conn_hub connect
+set js_hub [$conn_hub jet_stream]
+set kv_hub [$js_hub key_value]
+
+# connect to leaf server
+set conn_leaf [nats::connection new "MyNatsToLeaf"]
+$conn_leaf configure -servers nats://localhost:4111 -user acc -password acc
+$conn_leaf connect
+set js_leaf [$conn_leaf jet_stream]
+set kv_leaf [$js_leaf key_value]
+
+# connect to leaf server but use "hub" domain
+set js_leaf_to_hub [$conn_leaf jet_stream -domain hub]
+set kv_leaf_to_hub [$js_leaf_to_hub key_value]
+
+puts \n
+puts "Creating bucket 'kv_hub' in hub server..."
+$kv_hub add kv_hub
+
+puts "Setting value 'value1' for key 'key1' in 'kv_hub'..."
+$kv_hub put kv_hub key1 value1
+
+set val [$kv_leaf_to_hub get kv_hub key1]
+puts "Value '[dict get $val value]' was read from 'kv_hub' using leaf connection with specified 'hub' domain..."
+puts \n
+
+puts "Creating bucket 'kv_leaf_mirror' (using leaf connection) which mirrors 'kv_hub' from 'hub' domain..."
+$kv_leaf add kv_leaf_mirror -mirror_name kv_hub -mirror_domain hub
+puts "All messages in 'kv_leaf_mirror' are mirrored from 'kv_hub'"
+
+set history [$kv_leaf history kv_leaf_mirror]
+puts "Using 'kv_leaf_mirror' we can do all operations e.g. load history: $history"
+puts "Reads from 'kv_leaf_mirror' will be direct, but direct write to 'kv_leaf_mirror' is disabled"
+puts "All write messages (put, del...) will be send to original 'kv_hub'"
+puts "TCL client takes care of that under the hood"
+puts \n
+
+puts "Leaf connection and 'kv_leaf_mirror' are used to set value 'val_from_leaf' on key 'key2' on 'kv_hub'"
+$kv_leaf put kv_leaf_mirror key2 "val_from_leaf"
+puts "This value was first set on 'kv_hub' and then propagated to 'kv_leaf_mirror'"
+
+puts "We can check if 'key2' exists on 'kv_hub' and is the same as we set it"
+set key2_on_hub [$kv_hub get kv_hub key2]
+puts "Value read from 'kv_hub': [dict get $key2_on_hub value]"
+
+# CLEAN UP
+
+$kv_leaf_to_hub destroy
+$js_leaf_to_hub destroy
+
+puts "Deleting \"kv_leaf_mirror\" in leaf domain"
+$kv_leaf del kv_leaf_mirror
+$kv_leaf destroy
+$js_leaf destroy
+$conn_leaf destroy
+
+puts "Deleting \"kv_hub\" in hub domain"
+$kv_hub del kv_hub
+$kv_hub destroy
+$js_hub destroy
+$conn_hub destroy
+
+puts \n

--- a/examples/kv_watch.tcl
+++ b/examples/kv_watch.tcl
@@ -1,0 +1,73 @@
+# EXAMPLE #8: Key-Value Store usage of watch
+# remember to start nats-server with -js to enable JetStream and -sd to set the storage directory
+
+package require nats
+set conn [nats::connection new "MyNats"]
+$conn configure -servers nats://localhost:4222
+$conn connect
+set js [$conn jet_stream -timeout 2000]
+set kv [$js key_value]
+
+set bucket MY_KEY_VALUE
+
+##### WATCH #####
+
+puts "This program will show usage of \"watch\" method.\
+\"watch\" is called here with \"-include_history\" flag that will cause all available messages for key \"key1\" to be delivered.\
+After that \"end_of_initial_data\" marker will be delivered to distinguish between data that already existed in bucket and new updates.\
+There are two more updates made after \"watch\" has started - both will be delivered to \"callback\" method and the seconds one will end this showcase."
+
+# create a new key-value store named "MY_KEY_VALUE" with history of 10 messages per key
+puts "\nCreating new bucket named \"$bucket\"..."
+$kv add $bucket -history 10
+
+# put (and delete) some values to "key1" key
+puts "Setting some history of updates on \"key1\" key..."
+$kv put $bucket key1 "hi, it's my FIRST message"
+$kv del $bucket key1 ;# delete last value (only to see it in history) - operation of this entry would be "DEL"
+$kv put $bucket key1 "hi, it's my SECOND message"
+
+proc callback {status msg} {
+    switch -- $status {
+        ok {
+            puts "There were some errors, but now everything is fine."
+        }
+        error {
+            puts "Got some error: $msg"
+        }
+        end_of_initial_data {
+            puts "\nAll historic data has been received. From now on updates will be displayed."
+        }
+        "" {
+            if {[dict get $msg operation] eq "PUT"} {
+                puts "\nGot new value: [dict get $msg value]"
+            }
+            if {[dict get $msg operation] eq "DEL"} {
+                puts "\nGot delete marker"
+            }
+            if {[dict get $msg value] eq "End program"} {
+                set ::end_program true
+            }
+        }
+        default {
+            throw error "This should never happen"
+        }
+    }
+}
+
+set watch_id [$kv watch $bucket key1 -callback callback -include_history true]
+
+after 2000 [list $kv put $bucket key1 "Some update for \"key1\""]
+after 5000 [list $kv put $bucket key1 "End program"]
+
+vwait ::end_program
+
+##### CLEANUP #####
+
+puts "\nRemoving \"$bucket\" bucket and ending program..."
+$kv unwatch $watch_id
+$kv del $bucket
+
+$kv destroy
+$js destroy
+$conn destroy

--- a/jet_stream.tcl
+++ b/jet_stream.tcl
@@ -6,11 +6,14 @@
 
 oo::class create ::nats::jet_stream {
     variable conn _timeout api_prefix pull_reqs
+
+    variable domain
     
     # do NOT call directly! instead use [$connection jet_stream]
     constructor {c t d} {
         set conn $c
         set _timeout $t ;# avoid clash with -timeout option when using _parse_args
+        set domain $d
         if {$d eq ""} {
             set api_prefix \$JS.API
         } else {
@@ -28,14 +31,19 @@ oo::class create ::nats::jet_stream {
     # nats schema info --yaml io.nats.jetstream.api.v1.stream_msg_get_request
     # nats schema info --yaml io.nats.jetstream.api.v1.stream_msg_get_response
     method stream_msg_get {stream args} {
-        set spec {last_by_subj valid_str null
-                  next_by_subj valid_str null
-                  seq          int null}
+        set spec {
+            last_by_subj      {type valid_str default null}
+            next_by_subj      {type valid_str default null}
+            seq               {type int default null}
+        }
 
         set response [my ApiRequest "STREAM.MSG.GET.$stream" [nats::_dict2json $spec $args]]
         set encoded_msg [dict get $response message] ;# it is encoded in base64
         set data [binary decode base64 [dict lookup $encoded_msg data]]
         set msg [nats::msg create [dict get $encoded_msg subject] -data $data]
+        if {[$conn cget -utf8_convert]} {
+            set msg [encoding convertfrom utf-8 $msg]
+        }
         dict set msg seq [dict get $encoded_msg seq]
         dict set msg time [dict get $encoded_msg time]
         set header [binary decode base64 [dict lookup $encoded_msg hdrs]]
@@ -47,8 +55,10 @@ oo::class create ::nats::jet_stream {
     # nats schema info --yaml io.nats.jetstream.api.v1.stream_msg_delete_request
     # nats schema info --yaml io.nats.jetstream.api.v1.stream_msg_delete_response
     method stream_msg_delete {stream args} {
-        set spec {no_erase bool null
-                  seq      int NATS_TCL_REQUIRED}
+        set spec {
+            no_erase      {type bool default null}
+            seq           {type int default NATS_TCL_REQUIRED}
+        }
         set response [my ApiRequest "STREAM.MSG.DELETE.$stream" [nats::_dict2json $spec $args]]
         return [dict get $response success]
     }
@@ -383,33 +393,52 @@ oo::class create ::nats::jet_stream {
     # nats schema info --yaml io.nats.jetstream.api.v1.stream_create_response
     method add_stream {stream args} {
         # follow the same order of fields as in https://github.com/nats-io/nats.py/blob/main/nats/js/api.py
-        set spec {name             valid_str NATS_TCL_REQUIRED
-                  description      valid_str null
-                  subjects         list NATS_TCL_REQUIRED
-                  retention        {enum limits interest workqueue} limits
-                  max_consumers    int null
-                  max_msgs         int null
-                  max_bytes        int null
-                  discard          {enum new old} old
-                  max_age          ns null
-              max_msgs_per_subject int null
-                  max_msg_size     int null
-                  storage          {enum memory file} file
-                  num_replicas     int null
-                  no_ack           bool null
-                  duplicate_window ns null
-                  sealed           bool null
-                  deny_delete      bool null
-                  deny_purge       bool null
-                 allow_rollup_hdrs bool null
-                  allow_direct     bool null
-                  mirror_direct    bool null}
-        
+        set spec {
+            name                    {type valid_str default NATS_TCL_REQUIRED}
+            description             {type valid_str default null}
+            subjects                {type list default null}
+            retention               {type {enum limits interest workqueue} default limits}
+            max_consumers           {type int default null}
+            max_msgs                {type int default null}
+            max_bytes               {type int default null}
+            discard                 {type {enum new old} default old}
+            max_age                 {type ns default null}
+            max_msgs_per_subject    {type int default null}
+            max_msg_size            {type int default null}
+            storage                 {type {enum memory file} default file}
+            num_replicas            {type int default null}
+            no_ack                  {type bool default null}
+            duplicate_window        {type ns default null}
+            sealed                  {type bool default null}
+            deny_delete             {type bool default null}
+            deny_purge              {type bool default null}
+            allow_rollup_hdrs       {type bool default null}
+            allow_direct            {type bool default null}
+            mirror                  {type object default null spec {
+                name {type valid_str default null}
+                external {type object default null spec {
+                    api {type valid_str default null}
+                }}
+            }}
+            sources                 {type object_list default null spec {
+                name {type valid_str default null}
+                external {type object default null spec {
+                    api {type valid_str default null}
+                }}
+            }}
+        }
+
         if {![my CheckFilenameSafe $stream]} {
             throw {NATS ErrInvalidArg} "Invalid stream name $stream"
         }
-            
         dict set args name $stream
+
+        set flags [lmap flag [dict keys $args] {string trimleft $flag "-"}]
+        if {"subjects" ni $flags && "mirror" ni $flags && "sources" ni $flags} {
+            # for mirroring or sourcing subjects are not required
+            throw {NATS ErrInvalidArg} "Stream should have subjects defined"
+        }
+
         set response [my ApiRequest "STREAM.CREATE.$stream" [nats::_dict2json $spec $args]]
         # response fields: config, created (timestamp), state, did_create
         set result_config [dict get $response config]
@@ -471,6 +500,20 @@ oo::class create ::nats::jet_stream {
         }
         return [dict get $response streams]
     }
+
+    ### KV STORE ###
+
+    method key_value {args} {
+        nats::_parse_args $args {
+            check_bucket bool true
+            timeout pos_int 0
+            read_only bool false
+        }
+        if {$timeout == 0} {
+            set timeout $_timeout
+        }
+        return [::nats::key_value new $conn [self] $domain $timeout $check_bucket $read_only]
+    }
     
     # userCallback args: timedOut pubAck error
     method PublishCallback {userCallback timedOut msg} {
@@ -514,7 +557,7 @@ proc ::nats::_checkJsError {msg} {
     }
 }
 
-proc ::nats::_format_json {name val type} {
+proc ::nats::_format_json {name val type spec} {
     set errMsg "Invalid value for the $type option $name : $val"
     switch -- $type {
         valid_str {
@@ -544,6 +587,17 @@ proc ::nats::_format_json {name val type} {
                         json::write string $element
                     }]]
         }
+        object {
+            if {[llength $val] == 0} {
+                throw {NATS ErrInvalidArg} $errMsg
+            }
+            return [::nats::_dict2json $spec $val]
+        }
+        object_list {
+            return [json::write array {*}[lmap element $val {
+                        ::nats::_dict2json $spec $element
+                    }]]
+        }
         ns {
             # val must be in milliseconds
             return [expr {entier($val*1000*1000)}]
@@ -562,11 +616,11 @@ proc ::nats::_format_enum {name val type} {
     return [json::write string $val]
 }
 
-proc ::nats::_choose_format {name val type} {
+proc ::nats::_choose_format {name val type {spec ""}} {
     if {[lindex $type 0] eq "enum"} {
         return [_format_enum $name $val $type]
     } else {
-        return [_format_json $name $val $type]
+        return [_format_json $name $val $type $spec]
     }
 }
 
@@ -610,13 +664,16 @@ proc ::nats::_dict2json {spec src} {
     foreach {k v} $src {
         dict set src_dict [string trimleft $k -] $v
     }
-    foreach {name type def} $spec {
-        set val [dict lookup $src_dict $name $def]
+    dict for {name definition} $spec {
+        set default [dict get $definition default]
+        set type [dict get $definition type]
+        set val [dict lookup $src_dict $name $default]
+
         if {$val eq "NATS_TCL_REQUIRED"} {
             throw {NATS ErrInvalidArg} "Option $name is required"
         }
         if {$val ne "null"} {
-            dict set json_dict $name [_choose_format $name $val $type]
+            dict set json_dict $name [_choose_format $name $val $type [dict lookup $definition spec ""]]
         }
     }
     if {[dict size $json_dict]} {

--- a/key_value.tcl
+++ b/key_value.tcl
@@ -1,0 +1,1028 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and  limitations under the License.
+
+namespace eval ::nats {}
+
+# based on https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-8.md
+oo::class create ::nats::key_value {
+    variable conn
+    variable status_var
+    variable js
+    variable kv_prefix
+    variable check_bucket_default
+    variable read_only
+
+    variable _timeout
+    variable requests
+    variable watch
+
+    constructor {connection jet_stream domain_name timeout check_bucket rd_only} {
+        set conn $connection
+        set status_var [${connection}::my varname status]
+        set js $jet_stream
+        if {$domain_name eq ""} {
+            set kv_prefix "\$KV"
+        } else {
+            set kv_prefix "\$JS.${domain_name}.API.\$KV"
+        }
+        set check_bucket_default $check_bucket
+        set read_only $rd_only
+
+        set _timeout $timeout ;# avoid clash with -timeout option when using _parse_args
+        array set requests {} ;# reqID -> dict
+        array set watch {} ;# watchID -> dict
+    }
+
+    method get {bucket key args} {
+        my CheckBucketName $bucket
+        my CheckKeyName $key
+
+        nats::_parse_args $args {
+            revision pos_int null
+        }
+
+        set stream "KV_${bucket}"
+        set subject "\$KV.*.${key}"
+
+        try {
+            if {[info exists revision]} {
+                set resp [$js stream_msg_get $stream -seq $revision]
+
+                if {[dict exists $resp subject] && [lindex [my SubjectToBucketKey [dict get $resp subject]] 1] ne $key} {
+                    throw {NATS KeyNotFound} "Key ${key} not found"
+                }
+            } else {
+                set resp [$js stream_msg_get $stream -last_by_subj $subject]
+            }
+        } trap {NATS ErrJSResponse 404 10037} {} {
+            throw {NATS KeyNotFound} "Key ${key} not found"
+        } trap {NATS ErrJSResponse 404 10059} {} {
+            throw {NATS BucketNotFound} "Bucket ${bucket} not found"
+        }
+        
+        set msg $resp
+
+        # handle case when key value has been deleted or purged
+        if {[dict exists $msg header]} {
+            set operation [nats::header lookup $msg KV-Operation ""]
+            if {$operation in [list "DEL" "PURGE"]} {
+                throw {NATS KeyNotFound} "Key ${key} not found"
+            }
+        }
+
+        return [my MessageToEntry $msg]
+    }
+
+    method put {bucket key value args} {
+        if {$read_only} {
+            throw {NATS KvReadOnly} "KV has been created in read-only mode"
+        }
+        my CheckBucketName $bucket
+        my CheckKeyName $key
+
+        nats::_parse_args $args [list \
+            check_bucket bool $check_bucket_default \
+        ]
+
+        set subject "${kv_prefix}.${bucket}.${key}"
+
+        if {$check_bucket} {
+            set config [my _checkBucket $bucket]
+            if {[dict exists $config mirror]} {
+                set subject "[dict get $config mirror bucket_subject].${key}"
+            }
+        }
+
+        set resp [$js publish $subject $value]
+        return [dict get $resp seq]
+    }
+
+    method create {bucket key value args} {
+        if {$read_only} {
+            throw {NATS KvReadOnly} "KV has been created in read-only mode"
+        }
+        my CheckBucketName $bucket
+        my CheckKeyName $key
+
+        nats::_parse_args $args [list \
+            check_bucket bool $check_bucket_default \
+        ]
+
+        set subject "${kv_prefix}.${bucket}.${key}"
+
+        if {$check_bucket} {
+            set config [my _checkBucket $bucket]
+            if {[dict exists $config mirror]} {
+                set subject "[dict get $config mirror bucket_subject].${key}"
+            }
+        }
+
+        set msg [nats::msg create $subject -data $value]
+        nats::header set msg Nats-Expected-Last-Subject-Sequence 0
+        
+        try {
+            set resp [$js publish_msg $msg]
+        } trap {NATS ErrJSResponse 400 10071} {msg} {
+            throw {NATS WrongLastSequence} $msg
+        }
+
+        return [dict get $resp seq]
+    }
+
+    method update {bucket key revision value args} {
+        if {$read_only} {
+            throw {NATS KvReadOnly} "KV has been created in read-only mode"
+        }
+        my CheckBucketName $bucket
+        my CheckKeyName $key
+
+        nats::_parse_args $args [list \
+            check_bucket bool $check_bucket_default \
+        ]
+
+        set subject "${kv_prefix}.${bucket}.${key}"
+
+        if {$check_bucket} {
+            set config [my _checkBucket $bucket]
+            if {[dict exists $config mirror]} {
+                set subject "[dict get $config mirror bucket_subject].${key}"
+            }
+        }
+
+        set msg [nats::msg create $subject -data $value]
+        nats::header set msg Nats-Expected-Last-Subject-Sequence $revision
+
+        try {
+            set resp [$js publish_msg $msg]
+        } trap {NATS ErrJSResponse 400 10071} {msg} {
+            throw {NATS WrongLastSequence} $msg
+        }
+
+        return [dict get $resp seq]
+    }
+
+    method del {bucket args} {
+        if {$read_only} {
+            throw {NATS KvReadOnly} "KV has been created in read-only mode"
+        }
+        my CheckBucketName $bucket
+        set key ""
+
+        # first argument is not a flag - it is key name
+        if {[lindex $args 0] ne "" && [string index [lindex $args 0] 0] ne "-"} {
+            set key [lindex $args 0]
+            my CheckKeyName $key
+            set args [lrange $args 1 end]
+        }
+
+        nats::_parse_args $args [list \
+            check_bucket bool $check_bucket_default \
+        ]
+
+        if {$check_bucket} {
+            set config [my _checkBucket $bucket]
+        }
+
+        if {$key ne ""} {
+            set subject "${kv_prefix}.${bucket}.${key}"
+            if {[info exists config] && [dict exists $config mirror]} {
+                set subject "[dict get $config mirror bucket_subject].${key}"
+            }
+            set msg [nats::msg create $subject]
+            nats::header set msg KV-Operation DEL
+            set resp [$js publish_msg $msg]
+            return
+        }
+
+        set stream "KV_${bucket}"
+        try {
+            $js delete_stream $stream
+        } trap {NATS ErrJSResponse 404 10059} {} {
+            throw {NATS BucketNotFound} "Bucket ${bucket} not found"
+        }
+
+        return
+    }
+
+    method purge {bucket key args} {
+        if {$read_only} {
+            throw {NATS KvReadOnly} "KV has been created in read-only mode"
+        }
+        my CheckBucketName $bucket
+        my CheckKeyName $key
+
+        nats::_parse_args $args [list \
+            check_bucket bool $check_bucket_default \
+        ]
+
+        set subject "${kv_prefix}.${bucket}.${key}"
+
+        if {$check_bucket} {
+            set config [my _checkBucket $bucket]
+            if {[dict exists $config mirror]} {
+                set subject "[dict get $config mirror bucket_subject].${key}"
+            }
+        }
+
+        set msg [nats::msg create $subject]
+        nats::header set msg KV-Operation PURGE Nats-Rollup sub
+        set resp [$js publish_msg $msg]
+
+        return $resp
+    }
+
+    method revert {bucket key revision args} {
+        if {$read_only} {
+            throw {NATS KvReadOnly} "KV has been created in read-only mode"
+        }
+        my CheckBucketName $bucket
+        my CheckKeyName $key
+
+        nats::_parse_args $args [list \
+            check_bucket bool $check_bucket_default \
+        ]
+
+        set subject "${kv_prefix}.${bucket}.${key}"
+        if {$check_bucket} {
+            set config [my _checkBucket $bucket]
+            if {[dict exists $config mirror]} {
+                set subject "[dict get $config mirror bucket_subject].${key}"
+            }
+        }
+
+        set entry [my get $bucket $key -revision $revision]
+
+        set resp [$js publish $subject [dict get $entry value]]
+        return [dict get $resp seq]
+    }
+
+    # check stream info to know if given stream even exists (or is mirror of another stream), in order to not wait for timeout if it doesn't
+    method _checkBucket {bucket} {
+        set stream "KV_${bucket}"
+        try {
+            set stream_info [$js stream_info $stream]
+        } trap {NATS ErrJSResponse 404 10059} {} {
+            throw {NATS BucketNotFound} "Bucket ${bucket} not found"
+        }
+
+        if {[dict exists $stream_info mirror name]} {
+            # kv is mirrored
+            set mirrored_stream_name [dict get $stream_info mirror name]
+            set mirrored_kv_name [string range $mirrored_stream_name 3 end] ;# remove "KV_" from "KV_bucket_name"
+            
+            set config [dict create \
+                mirror [dict create \
+                    bucket_name $mirrored_kv_name \
+                    bucket_subject "\$KV.${mirrored_kv_name}" \
+                ] \
+            ]
+
+            if {[dict exists $stream_info mirror external api] && [dict get $stream_info mirror external api] ne ""} {
+                set external_api [dict get $stream_info mirror external api]
+                dict set config mirror external_api $external_api
+                dict set config mirror bucket_subject "${external_api}.\$KV.${mirrored_kv_name}"
+            }
+
+            return $config
+        }
+
+        return [dict create]
+    }
+
+    ########## ADVANCED ##########
+
+    method history {bucket args} {
+        my CheckBucketName $bucket
+        set key ""
+
+        # first argument is not a flag - it is key name
+        if {[lindex $args 0] ne "" && [string index [lindex $args 0] 0] ne "-"} {
+            set key [lindex $args 0]
+            my CheckKeyName $key
+            set args [lrange $args 1 end]
+        }
+
+        if {$key eq ""} {
+            set key ">"
+        }
+
+        set spec [list \
+            timeout pos_int $_timeout \
+            check_bucket bool $check_bucket_default \
+        ]
+        nats::_parse_args $args $spec
+
+        set stream "KV_${bucket}"
+        set subject "\$KV.${bucket}.${key}"
+
+        if {$check_bucket} {
+            set config [my _checkBucket $bucket]
+            if {[dict exists $config mirror]} {
+                set subject "\$KV.[dict get $config mirror bucket_name].${key}"
+            }
+        }
+
+        set deliver_subject [$conn inbox]
+
+        # get unique ID that will be used to send "add_consumer" request
+        set reqID [set ${conn}::counters(request)]
+        incr reqID
+
+        set requests($reqID) [dict create bucket $bucket timeout false num_received 0]
+        set subscription [$conn subscribe $deliver_subject -dictmsg true -callback [mymethod MessageReceived $reqID]]
+        
+        # make sure it will return someday
+        after $timeout [mymethod MessageReceived $reqID "" "" "" 1]
+        
+        try {
+            set consumer [$js add_consumer $stream \
+                -deliver_policy "all" \
+                -ack_policy "none" \
+                -max_deliver 1 \
+                -filter_subject $subject \
+                -replay_policy "instant" \
+                -deliver_subject $deliver_subject \
+                -num_replicas 1 \
+                -mem_storage 1 \
+            ]
+        } trap {NATS ErrJSResponse 404 10059} {msg} {
+            throw {NATS BucketNotFound} "Bucket ${bucket} not found"
+        }
+
+        set consumer_name [dict get $consumer name]
+        set num_pending [dict get $consumer num_pending]
+
+        # go further if num_pending = 0 (no keys found)
+        while {$num_pending > [dict get $requests($reqID) num_received] && ![dict get $requests($reqID) timeout]} {
+            # next message (key) or timeout was received
+            nats::_coroVwait [self object]::requests($reqID)
+        }
+
+        $js delete_consumer $stream $consumer_name
+        $conn unsubscribe $subscription
+        set msgs [dict lookup $requests($reqID) msgs]
+        set timeout_fired [dict get $requests($reqID) timeout]
+        set num_received [dict get $requests($reqID) num_received]
+        unset requests($reqID)
+
+        if {$timeout_fired && $num_pending > $num_received} {
+            throw {NATS ErrTimeout} "timeout"
+        }
+
+        set history [list]
+        foreach msg $msgs {
+            lappend history [my MessageToEntry $msg]
+        }
+
+        return $history
+    }
+
+    method watch {bucket args} {
+        my CheckBucketName $bucket
+        set key ""
+
+        # first argument is not a flag - it is key name
+        if {[lindex $args 0] ne "" && [string index [lindex $args 0] 0] ne "-"} {
+            set key [lindex $args 0]
+
+            if {[string range $key end-1 end] eq ".>"} {
+                # can watch sub-keys
+                my CheckKeyName [string range $key 0 end-2]
+            } elseif {$key eq ">"} {
+                # watch all keys
+            } else {
+                my CheckKeyName $key
+            }
+            set args [lrange $args 1 end]
+        }
+
+        if {$key eq ""} {
+            set key ">"
+        }
+
+        set spec [list \
+            callback valid_str null \
+            include_history bool false \
+            updates_only bool false \
+            headers_only bool false \
+            ignore_deletes bool false \
+            idle_heartbeat pos_int 5000 \
+            check_bucket bool $check_bucket_default \
+        ]
+
+        nats::_parse_args $args $spec
+
+        if {![info exists callback]} {
+            throw {NATS ErrInvalidArg} "Callback option should be specified"
+        }
+
+        return [my WatchImpl $bucket $key \
+            -callback $callback \
+            -include_history $include_history \
+            -updates_only $updates_only \
+            -headers_only $headers_only \
+            -ignore_deletes $ignore_deletes\
+            -idle_heartbeat $idle_heartbeat \
+            -check_bucket $check_bucket \
+        ]
+    }
+
+    # based on Ordered Consumer (but without flow control) - message gaps and idle heartbeats are taken care of: 
+    # https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-17.md
+    # https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-15.md
+    method WatchImpl {bucket key args} {
+        set spec [list \
+            callback valid_str null \
+            include_history bool false \
+            updates_only bool false \
+            headers_only bool false \
+            ignore_deletes bool false \
+            idle_heartbeat pos_int 5000 \
+            check_bucket bool $check_bucket_default \
+            \
+            stream_seq pos_int null \
+            watch_id pos_int null \
+            initial_data bool true \
+            last_error str "" \
+        ]
+                
+        nats::_parse_args $args $spec
+
+        set stream "KV_${bucket}"
+        set subject "\$KV.${bucket}.${key}"
+        if {$check_bucket} {
+            set config [my _checkBucket $bucket]
+            if {[dict exists $config mirror]} {
+                set subject "\$KV.[dict get $config mirror bucket_name].${key}"
+            }
+        }
+
+        set deliver_subject [$conn inbox]
+
+        if {[info exists watch_id]} {
+            # preserve old id
+            set watchID $watch_id
+        } else {
+            # get unique ID that will be used to send "add_consumer" request and return it to user
+            set watchID [set ${conn}::counters(request)]
+            incr watchID
+        }
+
+        set watch($watchID) [dict create \
+            bucket $bucket \
+            key $key \
+            consumer_seq 0 \
+            include_history $include_history \
+            updates_only $updates_only \
+            headers_only $headers_only \
+            ignore_deletes $ignore_deletes \
+            idle_heartbeat $idle_heartbeat \
+            check_bucket $check_bucket \
+            deliver_subject $deliver_subject \
+            initial_data $initial_data \
+            last_error $last_error \
+            callback $callback \
+        ]
+
+        if {[info exists stream_seq]} {
+            dict set watch($watchID) stream_seq $stream_seq
+        }
+        set subscription [$conn subscribe $deliver_subject -dictmsg true -callback [mymethod WatchMessageReceived $deliver_subject $watchID]]
+
+        set options [list \
+            -ack_policy "none" \
+            -max_deliver 1 \
+            -filter_subject $subject \
+            -replay_policy "instant" \
+            -deliver_subject $deliver_subject \
+            -idle_heartbeat $idle_heartbeat \
+            -mem_storage true \
+            -num_replicas 1 \
+        ]
+
+        lappend options -headers_only $headers_only
+
+        if {[info exists stream_seq]} {
+            lappend options -opt_start_seq [expr {$stream_seq + 1}]
+            lappend options -deliver_policy "by_start_sequence"
+        } elseif {$include_history} {
+            lappend options -deliver_policy "all"
+
+            if {$updates_only} {
+                throw {NATS ErrInvalidArg} "Options -include_history and -updates_only cannot be true at the same time"
+            }
+        } elseif {$updates_only} {
+            lappend options -deliver_policy "new"
+        } else {
+            lappend options -deliver_policy "last_per_subject"
+        }
+
+        try {
+            set consumer [$js add_consumer $stream {*}$options]
+        } trap {NATS ErrJSResponse 404 10059} {msg} {
+            if {[info exists watch_id]} {
+                # trying to reset consumer - do not remove it completely
+                dict set watch($watchID) removed true
+            } else {
+                unset watch($watchID)
+            }
+            $conn unsubscribe $subscription
+            throw {NATS BucketNotFound} "Bucket ${bucket} not found"
+        } trap {} {msg opts} {
+            if {[info exists watch_id]} {
+                # trying to reset consumer - do not remove it completely
+                dict set watch($watchID) removed true
+            } else {
+                unset watch($watchID)
+            }
+            $conn unsubscribe $subscription
+            throw $opts $msg
+        }
+
+        dict set watch($watchID) consumer_name [dict get $consumer name]
+        dict set watch($watchID) subscription $subscription
+
+        return $watchID
+    }
+
+    method unwatch {watchID} {
+        return [my UnwatchImpl $watchID]
+    }
+
+    method UnwatchImpl {watchID args} {
+        if {![info exists watch($watchID)]} {
+            throw {NATS ErrInvalidArg} "There is no watch with that id"
+        }
+
+        set spec [list \
+            remove_completely bool true
+        ]
+                
+        nats::_parse_args $args $spec
+
+        set bucket [dict get $watch($watchID) bucket]
+        set stream "KV_${bucket}"
+        set consumer_name [dict lookup $watch($watchID) consumer_name ""]
+        set subscription [dict lookup $watch($watchID) subscription ""]
+
+        try {
+            if {$consumer_name ne ""} {
+                $js delete_consumer $stream $consumer_name
+                $conn unsubscribe $subscription
+            }
+        } trap {NATS ErrJSResponse 404 10014} {} {
+            # consumer not found - ignore it and ignore unsubscribe - it probably does not exists too
+        }
+
+        if {$remove_completely} {
+            unset watch($watchID)
+            # if there was restart planned than make sure it won't happen
+            after cancel [mymethod ResetWatch $watchID]
+        }
+
+        return
+    }
+
+    ########## MANAGING ##########
+
+    method add {bucket args} {
+        if {$read_only} {
+            throw {NATS KvReadOnly} "KV has been created in read-only mode"
+        }
+        my CheckBucketName $bucket
+        set stream "KV_${bucket}"
+
+        set options {
+            -storage file
+            -retention limits
+            -discard new
+            -max_msgs_per_subject 1
+            -num_replicas 1
+            -max_msgs -1
+            -max_msg_size -1
+            -max_bytes -1
+            -max_age 0
+            -duplicate_window 120000000000
+            -deny_delete 1
+            -deny_purge 0
+            -allow_rollup_hdrs 1
+        }
+
+        set argsMap {
+            -history            -max_msgs_per_subject
+            -storage            -storage
+            -ttl                -max_age
+            -max_value_size     -max_msg_size
+            -max_bucket_size    -max_bytes
+            -mirror_name        -mirror
+            -mirror_domain      -mirror
+        }
+
+        if {[llength $args] % 2} {
+            throw {NATS ErrInvalidArg} "Missing value for option [lindex $args end]"
+        }
+
+        dict for {key value} $args {
+            if {![dict exists $argsMap $key]} {
+                throw {NATS ErrInvalidArg} "Unknown option ${key}. Should be one of [dict keys $argsMap]"
+            }
+            switch -- $key {
+                -history {
+                    if {$value < 1} {
+                        throw {NATS ErrInvalidArg} "history must be greater than 0"
+                    }
+                    if {$value > 64} {
+                        throw {NATS ErrInvalidArg} "history must be less than 64"
+                    }
+
+                    dict set options [dict get $argsMap $key] $value
+                }
+                -mirror_domain {
+                    # mirror_domain is taken care of in "mirror_name"
+                }
+                -mirror_name {
+                    set mirror_info [dict create name "KV_${value}"]
+                    if {[dict exists $args "-mirror_domain"]} {
+                        dict set mirror_info external api "\$JS.[dict get $args "-mirror_domain"].API"
+                    }
+                    dict set options [dict get $argsMap $key] $mirror_info
+                }
+                default {
+                    dict set options [dict get $argsMap $key] $value
+                }
+            }
+        }
+
+        if {![dict exists $args -mirror_name]} {
+            # when kv is mirroring it does not listen on normal subjects
+            set subject "\$KV.${bucket}.>"
+            lappend options -subjects $subject
+        }
+
+        return [$js add_stream $stream {*}$options]
+    }
+
+    method info {bucket} {
+        my CheckBucketName $bucket
+        set stream "KV_${bucket}"
+        try {
+            set stream_info [$js stream_info $stream]
+
+            set kv_info [dict create]
+            dict set kv_info bucket $bucket
+            dict set kv_info stream $stream
+            dict set kv_info storage [dict get $stream_info config storage]
+            dict set kv_info history [dict get $stream_info config max_msgs_per_subject]
+            dict set kv_info ttl [dict get $stream_info config max_age]
+            dict set kv_info max_value_size [dict get $stream_info config max_msg_size]
+            dict set kv_info max_bucket_size [dict get $stream_info config max_bytes]
+
+            if {[dict exists $stream_info mirror]} {
+                dict set kv_info mirror [dict get $stream_info mirror]
+            }
+
+            dict set kv_info created [nats::time_to_millis [dict get $stream_info created]]
+            dict set kv_info values_stored [dict get $stream_info state messages]
+            dict set kv_info bytes_stored [dict get $stream_info state bytes]
+
+            dict set kv_info backing_store JetStream
+            dict set kv_info store_config [dict get $stream_info config]
+            dict set kv_info store_state [dict get $stream_info state]
+        } trap {NATS ErrJSResponse 404 10059} {} {
+            throw {NATS BucketNotFound} "Bucket ${bucket} not found"
+        }
+
+        return $kv_info
+    }
+
+    method ls {} {
+        set streams [$js stream_names]
+        set kv_list [list]
+        foreach stream $streams {
+            if {[string range $stream 0 2] eq "KV_"} {
+                lappend kv_list [string range $stream 3 end]
+            }
+        }
+
+        return $kv_list
+    }
+
+    method keys {bucket args} {
+        my CheckBucketName $bucket
+        set spec [list \
+            timeout pos_int $_timeout \
+        ]
+
+        nats::_parse_args $args $spec
+
+        set stream "KV_${bucket}"
+        set subject "\$KV.*.>" ;# bucket is not set in case it comes from a different domain
+        set deliver_subject [$conn inbox]
+
+        # get unique ID that will be used to send "add_consumer" request
+        set reqID [set ${conn}::counters(request)]
+        incr reqID
+
+        set requests($reqID) [dict create bucket $bucket timeout false num_received 0]
+        set subscription [$conn subscribe $deliver_subject -dictmsg true -callback [mymethod MessageReceived $reqID]]
+
+        # make sure it will return someday
+        after $timeout [mymethod MessageReceived $reqID "" "" "" 1]
+
+        try {
+            set consumer [$js add_consumer $stream \
+                -deliver_policy "last_per_subject" \
+                -ack_policy "none" \
+                -max_deliver 1 \
+                -filter_subject $subject \
+                -replay_policy "instant" \
+                -headers_only 1 \
+                -deliver_subject $deliver_subject \
+                -num_replicas 1 \
+            ]
+        } trap {NATS ErrJSResponse 404 10059} {msg} {
+            throw {NATS BucketNotFound} "Bucket ${bucket} not found"
+        }
+
+        set consumer_name [dict get $consumer name]
+        set num_pending [dict get $consumer num_pending]
+
+        # go further if num_pending = 0 (no keys found)
+        while {$num_pending > [dict get $requests($reqID) num_received] && ![dict get $requests($reqID) timeout]} {
+            # next message (key) or timeout was received
+            nats::_coroVwait [self object]::requests($reqID)
+        }
+
+        $js delete_consumer $stream $consumer_name
+        $conn unsubscribe $subscription
+        set msgs [dict lookup $requests($reqID) msgs]
+        set timeout_fired [dict get $requests($reqID) timeout]
+        set num_received [dict get $requests($reqID) num_received]
+        unset requests($reqID)
+
+        if {$timeout_fired && $num_pending > $num_received} {
+            throw {NATS ErrTimeout} "timeout"
+        }
+
+        set keys [list]
+        foreach msg $msgs {
+            if {[dict exists $msg header]} {
+                set operation [nats::header lookup $msg KV-Operation ""]
+                if {$operation in [list "DEL" "PURGE"]} {
+                    # key was deleted - do not add it
+                    continue;
+                }
+            }
+
+            set subject [dict get $msg subject]
+            lappend keys [join [lrange [split $subject "."] 2 end] "."]
+        }
+
+        return $keys
+    }
+
+    ########## HELPERS ##########
+
+    method MessageReceived {reqID subject msg reply {timeout 0}} {
+        if {![info exists requests($reqID)]} {
+            return
+        }
+
+        if {$timeout} {
+            dict set requests($reqID) timeout true
+            return
+        }
+
+        dict incr requests($reqID) num_received
+        dict lappend requests($reqID) msgs $msg
+    }
+
+    method WatchMessageReceived {deliver_subject watchID subject msg reply} {
+        if {![info exists watch($watchID)] || [dict lookup $watch($watchID) removed false]} {
+            return
+        }
+        if {[dict get $watch($watchID) deliver_subject] ne $deliver_subject} {
+            # should never happen, but if consumer has been recreated and old one somehow is still active,
+            # then make sure the old one won't work
+            return
+        }
+
+        # after 3 missed heartbeats reset consumer
+        after cancel [mymethod ResetWatch $watchID]
+        after [expr {[dict get $watch($watchID) idle_heartbeat] * 3}] [mymethod ResetWatch $watchID]
+
+        set last_consumer_seq [dict get $watch($watchID) consumer_seq]
+        set last_stream_seq [dict lookup $watch($watchID) stream_seq ""]
+
+        if {[nats::header lookup $msg Status 0] == 100} {
+            # idle heartbeat
+            set num_pending 0
+            set stream_seq [nats::header lookup $msg Nats-Last-Stream ""]
+            set consumer_seq [nats::header lookup $msg Nats-Last-Consumer ""]
+        } else {
+            set num_pending [lindex [split $reply "."] end]
+            set stream_seq [lindex [split $reply "."] end-3]
+            set consumer_seq [lindex [split $reply "."] end-2]
+        }
+
+        if {$last_consumer_seq + 1 < $consumer_seq} {
+            # difference between current message seq and last delivered is more than 1
+            # there has been a Message Gap - restart consumer using last stream seq
+            after cancel [mymethod ResetWatch $watchID]
+            my ResetWatch $watchID
+            return
+        }
+
+        dict set watch($watchID) consumer_seq $consumer_seq
+
+        set last_error [dict get $watch($watchID) last_error]
+        dict set watch($watchID) last_error ""
+
+        if {$last_stream_seq ne "" && $stream_seq <= $last_stream_seq} {
+            # already delivered - do not change current stream seq and do not redeliver to user
+            if {$last_error ne ""} {
+                # there were errors before, but connection has been reestablished - notify user
+                set callback [dict get $watch($watchID) callback]
+                after 0 [list $callback ok {}]
+            }
+            return
+        }
+
+        dict set watch($watchID) stream_seq $stream_seq
+
+        if {[nats::header lookup $msg Status 0] == 100} {
+            # idle heartbeat
+            if {$num_pending == 0 && [dict get $watch($watchID) initial_data]} {
+                # send End Of Initial Data signal
+                dict set watch($watchID) initial_data false
+                set callback [dict get $watch($watchID) callback]
+                after 0 [list $callback end_of_initial_data {}]
+            }
+            if {$last_error ne ""} {
+                # there were errors before, but connection has been reestablished - notify user
+                set callback [dict get $watch($watchID) callback]
+                after 0 [list $callback ok {}]
+            }
+            return
+        }
+
+        set entry [my MessageToEntry $msg]
+        if {[dict get $entry operation] ne "PUT" && [dict get $watch($watchID) ignore_deletes]} {
+            if {$last_error ne ""} {
+                # there were errors before, but connection has been reestablished - notify user
+                set callback [dict get $watch($watchID) callback]
+                after 0 [list $callback ok {}]
+            }
+            return
+        }
+
+        set callback [dict get $watch($watchID) callback]
+        after 0 [list $callback {} $entry]
+
+        if {$num_pending == 0 && [dict get $watch($watchID) initial_data]} {
+            # send End Of Initial Data signal
+            dict set watch($watchID) initial_data false
+            set callback [dict get $watch($watchID) callback]
+            after 0 [list $callback end_of_initial_data {}]
+        }
+    }
+
+    method ResetWatch {watchID} {
+        if {![info exists watch($watchID)]} {
+            return
+        }
+
+        if {[set $status_var] != $::nats::status_connected} {
+            # nats-server is disconnected - after it connects it will probably restore consumer
+            # if it happens we will receive some messages and this reset will be canceled
+            set new_error "Server disconnected"
+            if {$new_error ne [dict get $watch($watchID) last_error]} {
+                dict set watch($watchID) last_error $new_error
+                set callback [dict get $watch($watchID) callback]
+                after 0 [list $callback error $new_error]
+            }
+            after [dict get $watch($watchID) idle_heartbeat] [mymethod ResetWatch $watchID]
+            return;
+        }
+
+        dict set watch($watchID) deliver_subject "" ;# make sure no further messages will be processed from this subscription
+
+        try {
+            # make sure watch($watchID) is not completely removed
+            if {![dict lookup $watch($watchID) removed false]} {
+                # subscriptions etc were not removed yet
+                my UnwatchImpl $watchID -remove_completely false
+                dict set watch($watchID) removed true
+            }
+
+            set options [dict create \
+                -callback [dict get $watch($watchID) callback] \
+                -include_history [dict get $watch($watchID) include_history] \
+                -updates_only [dict get $watch($watchID) updates_only] \
+                -headers_only [dict get $watch($watchID) headers_only] \
+                -ignore_deletes [dict get $watch($watchID) ignore_deletes] \
+                -check_bucket [dict get $watch($watchID) check_bucket] \
+                -idle_heartbeat [dict get $watch($watchID) idle_heartbeat] \
+                -watch_id $watchID \
+                -initial_data [dict get $watch($watchID) initial_data] \
+                -last_error [dict get $watch($watchID) last_error] \
+            ]
+
+            if {[dict exists $watch($watchID) stream_seq]} {
+                dict set options -stream_seq [dict get $watch($watchID) stream_seq]
+            }
+
+            set bucket [dict get $watch($watchID) bucket]
+            set key [dict get $watch($watchID) key]
+
+            my WatchImpl $bucket $key {*}$options
+        } trap {} {msg opts} {
+            # probably consumer cannot be removed or created again - try again in few seconds
+            set new_error "Error resetting consumer: $msg"
+            if {$new_error ne [dict get $watch($watchID) last_error]} {
+                dict set watch($watchID) last_error $new_error
+                set callback [dict get $watch($watchID) callback]
+                after 0 [list $callback error $new_error]
+            }
+            after [dict get $watch($watchID) idle_heartbeat] [mymethod ResetWatch $watchID]
+        }
+    }
+
+    method MessageToEntry {msg} {
+        # return dict representation of Entry https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-8.md#entry
+        # reply will be in format:  $JS.ACK.<domain>.<account hash>.<stream name>.<consumer name>.<num delivered>.<stream sequence>.<consumer sequence>.<timestamp>.<num pending>
+        # or                        $JS.ACK.<stream name>.<consumer name>.<num delivered>.<stream sequence>.<consumer sequence>.<timestamp>.<num pending>
+
+        lassign [my SubjectToBucketKey [dict get $msg subject]] bucket key
+        set value ""
+        if {[dict exists $msg data]} {
+            set value [dict get $msg data]
+        }
+        set header [dict create]
+        if {[dict exist $msg header]} {
+            set header [dict get $msg header]
+        }
+        set operation [my HeadersToOperation $header]
+        set entry [dict create \
+            value $value \
+            bucket $bucket \
+            key $key \
+            operation $operation \
+        ]
+
+        if {[dict exists $msg seq]} {
+            dict set entry revision [dict get $msg seq]
+        } elseif {[dict exists $msg reply]} {
+            # get seq from reply subject (stream sequence)
+            dict set entry revision [lindex [split [dict get $msg reply] "."] end-3]
+        }
+
+        if {[dict exists $msg time]} {
+            dict set entry created [::nats::time_to_millis [dict get $msg time]]
+        } elseif {[dict exists $msg reply]} {
+            # get time from reply subject (timestamp)
+            set ns [lindex [split [dict get $msg reply] "."] end-1]
+            dict set entry created $ns
+            ::nats::_ns2ms entry created
+        }
+
+        return $entry
+    }
+
+    method SubjectToBucketKey {subject} {
+        # return list of bucket and key from subject
+        set parts [split $subject "."]
+        set bucket [lindex $parts 1]
+        set key [join [lindex $parts 2 end] "."]
+        return [list $bucket $key]
+    }
+
+    method HeadersToOperation {headers} {
+        # return operation from headers
+        if {[dict exists $headers KV-Operation]} {
+            return [dict get $headers KV-Operation]
+        }
+        return "PUT"
+    }
+
+    method CheckBucketName {bucket} {
+        if {![regexp {^[a-zA-Z0-9_-]+$} $bucket]} {
+            throw {NATS ErrInvalidArg} "Bucket \"$bucket\" is not valid bucket name"
+        }
+    }
+
+    method CheckKeyName {key} {
+        if {[string index $key 0] eq "."} {
+            throw {NATS ErrInvalidArg} "Keys cannot start with \".\""
+        }
+        if {[string index $key end] eq "."} {
+            throw {NATS ErrInvalidArg} "Keys cannot end with \".\""
+        }
+        if {[string range $key 0 2] eq "_kv"} {
+            throw {NATS ErrInvalidArg} "Keys cannot start with \"_kv\", which is reserved for internal use"
+        }
+        if {![regexp {^[-/_=\.a-zA-Z0-9]+$} $key]} {
+            throw {NATS ErrInvalidArg} "Key \"$key\" is not valid key name"
+        }
+    }
+}

--- a/nats_client.tcl
+++ b/nats_client.tcl
@@ -1346,6 +1346,18 @@ proc ::nats::timestamp {} {
                 [expr {$t % 1000}] ]
 }
 
+# 2023-05-30T07:06:22.864305Z to milliseconds
+proc ::nats::time_to_millis {time} {
+  set seconds 0
+  if {[regexp -all {^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}).(\d+)Z$} $time -> year month day hour minute second micro]} {
+    scan [string range $micro 0 2] %d millis ;# could be "081" that would be treated as octal number
+    set seconds [clock scan "${year}-${month}-${day} ${hour}:${minute}:${second}" -format "%Y-%m-%d %T" -gmt 1]
+    return  [expr {$seconds *  1000 + $millis}]
+  }
+
+  throw {NATS InvalidTime} "Invalid time format ${time}"
+}
+
 # ------------------------ all following procs are private! --------------------------------------
 proc ::nats::_coroVwait {var} {
     if {[info coroutine] eq ""} {

--- a/pkgIndex.tcl
+++ b/pkgIndex.tcl
@@ -3,5 +3,6 @@ package ifneeded nats 2.0.2 \
     source [file join $dir server_pool.tcl]
     source [file join $dir nats_client.tcl]
     source [file join $dir jet_stream.tcl]
+    source [file join $dir key_value.tcl]
     package provide nats 2.0.2
 }} $dir]

--- a/tests/conf/accounts.conf
+++ b/tests/conf/accounts.conf
@@ -1,0 +1,10 @@
+accounts {
+    SYS: {
+        users: [{user: admin, password: admin}]
+    },
+    ACC: {
+        users: [{user: acc, password: acc}],
+        jetstream: enabled
+    }
+}
+system_account: SYS

--- a/tests/conf/hub.conf
+++ b/tests/conf/hub.conf
@@ -1,0 +1,9 @@
+port: 4222
+server_name: hub-server
+jetstream {
+    domain=hub
+}
+leafnodes {
+    port: 7422
+}
+include ./accounts.conf

--- a/tests/conf/leaf.conf
+++ b/tests/conf/leaf.conf
@@ -1,0 +1,18 @@
+port: 4111
+server_name: leaf-server
+jetstream {
+    domain=leaf
+}
+leafnodes {
+    remotes = [
+        {
+            urls: ["nats://admin:admin@0.0.0.0:7422"]
+            account: "SYS"
+        },
+        {
+            urls: ["nats://acc:acc@0.0.0.0:7422"]
+            account: "ACC"
+        }
+    ]
+}
+include ./accounts.conf

--- a/tests/jet_stream_mgmt.test
+++ b/tests/jet_stream_mgmt.test
@@ -231,6 +231,24 @@ test js_mgmt-11.1 "Delete a message directly from a stream" -body {
     $js stream_msg_delete MY_STREAM -seq [nats::msg seq $msg]  ;# if not found, this will throw ErrJSResponse 400
 } -result true
 
+test js_mgmt-12.1 "Create stream that mirrors another one" -body {
+    set response [$js add_stream MY_STREAM_MIRROR -mirror [dict create name MY_STREAM]]
+    assert {[dict get $response did_create]}
+    set actual_config [dict get $response config]
+    assert {[dict get $actual_config mirror] == [dict create name MY_STREAM]}
+} -cleanup {
+    $js delete_stream MY_STREAM_MIRROR
+}
+
+test js_mgmt-12.2 "Create stream that sources another one" -body {
+    set response [$js add_stream MY_STREAM_SOURCES -sources [list [dict create name MY_STREAM]]]
+    assert {[dict get $response did_create]}
+    set actual_config [dict get $response config]
+    assert {[dict get $actual_config sources] == [list [dict create name MY_STREAM]]}
+} -cleanup {
+    $js delete_stream MY_STREAM_SOURCES
+}
+
 $js destroy
 $conn destroy
 stopNats NATS

--- a/tests/key_value.test
+++ b/tests/key_value.test
@@ -1,0 +1,438 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and  limitations under the License.
+source test_utils.tcl
+
+tcltest::customMatch dict {apply {{expected actual} {
+  if {[dict size $expected] != [dict size $actual]} { return 0 }
+  dict for {key value} $actual {
+    if {![dict exists $expected $key]} {
+      return 0
+    }
+    if {$value ne [dict get $expected $key]} {
+      return 0
+    }
+  }
+
+  return 1
+}}}
+
+set bucket MY_TEST_BUCKET
+startNats NATS_JS -js --store_dir [tcltest::temporaryDirectory];# start nats with Jet Stream
+
+set conn [nats::connection new]
+$conn configure -servers nats://localhost:4222 -utf8_convert true
+$conn connect
+set js [$conn jet_stream]
+set kv [$js key_value]
+
+# cleanup if previous test has not cleaned up correctly
+set ls [execNatsCmd kv ls]
+if {$bucket in $ls} {
+    execNatsCmd kv del $bucket -f
+}
+
+########## GET ##########
+
+test key_value-get-1 "Get existing key" -setup {
+    execNatsCmd kv add $bucket
+    execNatsCmd kv put $bucket key1 value1
+} -body {
+    set value [$kv get $bucket key1]
+    dict filter $value key value key operation bucket revision
+} -match dict -result [dict create value value1 operation PUT key key1 bucket $bucket revision 1] -cleanup {
+    execNatsCmd kv del $bucket -f
+}
+
+test key_value-get-2 "Get existing key for specified revision" -setup {
+    execNatsCmd kv add $bucket --history=5
+    execNatsCmd kv put $bucket key1 value1
+    execNatsCmd kv put $bucket key1 target_value
+    execNatsCmd kv put $bucket key1 value3
+} -body {
+    set value [$kv get $bucket key1 -revision 2]
+    dict filter $value key value key operation bucket revision
+} -match dict -result [dict create value target_value operation PUT key key1 bucket $bucket revision 2] -cleanup {
+    execNatsCmd kv del $bucket -f
+}
+
+test key_value-get-3 "Throw KeyNotFound for non-existing key" -setup {
+    execNatsCmd kv add $bucket
+} -body {
+    if {![catch {
+        $kv get $bucket key1
+    } err errOpts]} {
+        throw {TEST DidNotThrow} "Did not throw"
+    }
+    assert {[dict get $errOpts -errorcode] eq {NATS KeyNotFound}}
+    set err
+} -result {Key key1 not found} -cleanup {
+    execNatsCmd kv del $bucket -f
+}
+
+test key_value-get-4 "Throw KeyNotFound for deleted key" -setup {
+    execNatsCmd kv add $bucket
+    execNatsCmd kv put $bucket key1 value1
+    execNatsCmd kv del $bucket key1 -f
+} -body {
+    if {![catch {
+        $kv get $bucket key1
+    } err errOpts]} {
+        throw {TEST DidNotThrow} "Did not throw"
+    }
+    assert {[dict get $errOpts -errorcode] eq {NATS KeyNotFound}}
+    set err
+} -result {Key key1 not found} -cleanup {
+    execNatsCmd kv del $bucket -f
+}
+
+test key_value-get-5 "Throw KeyNotFound for non-existing revision" -setup {
+    execNatsCmd kv add $bucket
+    execNatsCmd kv put $bucket key1 value1
+} -body {
+    if {![catch {
+        $kv get $bucket key1 -revision 2
+    } err errOpts]} {
+        throw {TEST DidNotThrow} "Did not throw"
+    }
+    assert {[dict get $errOpts -errorcode] eq {NATS KeyNotFound}}
+    set err
+} -result {Key key1 not found} -cleanup {
+    execNatsCmd kv del $bucket -f
+}
+
+test key_value-get-6 "Throw KeyNotFound for specified revision, that belongs to another key" -setup {
+    execNatsCmd kv add $bucket
+    execNatsCmd kv put $bucket key1 value1
+    execNatsCmd kv put $bucket key2 value2
+} -body {
+    if {![catch {
+        $kv get $bucket key1 -revision 2
+    } err errOpts]} {
+        throw {TEST DidNotThrow} "Did not throw"
+    }
+    assert {[dict get $errOpts -errorcode] eq {NATS KeyNotFound}}
+    set err
+} -result {Key key1 not found} -cleanup {
+    execNatsCmd kv del $bucket -f
+}
+
+test key_value-get-7 "Throw BucketNotFound for non existing bucket" -body {
+    if {![catch {
+        $kv get $bucket key1
+    } err errOpts]} {
+        throw {TEST DidNotThrow} "Did not throw"
+    }
+    assert {[dict get $errOpts -errorcode] eq {NATS BucketNotFound}}
+    set err
+} -result "Bucket $bucket not found"
+
+test key_value-get-8 "Throw ErrInvalidArg for bad bucket name" -body {
+    if {![catch {
+        $kv get ".some.bad.bucket." key1
+    } err errOpts]} {
+        throw {TEST DidNotThrow} "Did not throw"
+    }
+    assert {[dict get $errOpts -errorcode] eq {NATS ErrInvalidArg}}
+    set err
+} -result "Bucket \".some.bad.bucket.\" is not valid bucket name"
+
+test key_value-get-9 "Throw ErrInvalidArg for bad key name" -body {
+    if {![catch {
+        $kv get $bucket "???"
+    } err errOpts]} {
+        throw {TEST DidNotThrow} "Did not throw"
+    }
+    assert {[dict get $errOpts -errorcode] eq {NATS ErrInvalidArg}}
+    set err
+} -result "Key \"???\" is not valid key name"
+
+# ########## PUT ##########
+
+test key_value-put-1 "Put key" -setup {
+    execNatsCmd kv add $bucket
+} -body {
+    set revision [$kv put $bucket key1 value1]
+
+    set new_val [exec nats kv get $bucket key1 --raw]
+    assert {$new_val eq "value1"}
+
+    set revision
+} -result {1} -cleanup {
+    execNatsCmd kv del $bucket -f
+}
+
+test key_value-put-2 "Throw BucketNotFound when calling put on non-existing bucket with -check_bucket set to true" -body {
+    if {![catch {
+        $kv put "non-existing-bucket" key1 value1 -check_bucket true
+    } err errOpts]} {
+        throw {TEST DidNotThrow} "Did not throw"
+    }
+    assert {[dict get $errOpts -errorcode] eq {NATS BucketNotFound}}
+    set err
+} -result "Bucket non-existing-bucket not found"
+
+test key_value-put-3 "Throw NoResponders/Timeout when calling put on non-existing bucket with -check_bucket set to false" -body {
+    if {![catch {
+        $kv put "non-existing-bucket" key1 value1 -check_bucket false
+    } err errOpts]} {
+        throw {TEST DidNotThrow} "Did not throw"
+    }
+    assert {[dict get $errOpts -errorcode] eq {NATS ErrNoResponders}}
+    set err
+} -result "No responders available for request"
+
+test key_value-put-4 "Throw KvReadOnly when calling put on read-only kv" -body {
+    set read_only_kv [$js key_value -read_only true]
+    if {![catch {
+        $read_only_kv put "non-existing-bucket" key1 value1 -check_bucket false
+    } err errOpts]} {
+        throw {TEST DidNotThrow} "Did not throw"
+    }
+    $read_only_kv destroy
+    assert {[dict get $errOpts -errorcode] eq {NATS KvReadOnly}}
+    set err
+} -result "KV has been created in read-only mode"
+
+########## CREATE ##########
+
+test key_value-create-1 "Create key" -setup {
+    execNatsCmd kv add $bucket
+} -body {
+    $kv create $bucket key1 value1
+} -result {1} -cleanup {
+    execNatsCmd kv del $bucket -f
+}
+
+test key_value-create-2 "Throw WrongLastSequence if key already exists" -setup {
+    execNatsCmd kv add $bucket
+    execNatsCmd kv put $bucket key1 some_val
+} -body {
+    if {![catch {
+        $kv create $bucket key1 value1
+    } err errOpts]} {
+        throw {TEST DidNotThrow} "Did not throw"
+    }
+    assert {[dict get $errOpts -errorcode] eq {NATS WrongLastSequence}}
+    set err
+} -result "wrong last sequence: 1" -cleanup {
+    execNatsCmd kv del $bucket -f
+}
+
+test key_value-create-3 "Throw BucketNotFound when calling create on non-existing bucket with -check_bucket set to true" -body {
+    if {![catch {
+        $kv create "non-existing-bucket" key1 value1 -check_bucket true
+    } err errOpts]} {
+        throw {TEST DidNotThrow} "Did not throw"
+    }
+    assert {[dict get $errOpts -errorcode] eq {NATS BucketNotFound}}
+    set err
+} -result "Bucket non-existing-bucket not found"
+
+test key_value-create-4 "Throw NoResponders/Timeout when calling create on non-existing bucket with -check_bucket set to false" -body {
+    if {![catch {
+        $kv create "non-existing-bucket" key1 value1 -check_bucket false
+    } err errOpts]} {
+        throw {TEST DidNotThrow} "Did not throw"
+    }
+    assert {[dict get $errOpts -errorcode] eq {NATS ErrNoResponders}}
+    set err
+} -result "No responders available for request"
+
+########## UPDATE ##########
+
+test key_value-update-1 "Update key" -setup {
+    execNatsCmd kv add $bucket
+    execNatsCmd kv put $bucket key1 some_val
+} -body {
+    $kv update $bucket key1 1 value1
+} -result {2} -cleanup {
+    execNatsCmd kv del $bucket -f
+}
+
+test key_value-update-2 "Throw WrongLastSequence if revision does not match with requested" -setup {
+    execNatsCmd kv add $bucket
+    execNatsCmd kv put $bucket key1 some_val
+} -body {
+    if {![catch {
+        $kv update $bucket key1 2 value1
+    } err errOpts]} {
+        throw {TEST DidNotThrow} "Did not throw"
+    }
+    assert {[dict get $errOpts -errorcode] eq {NATS WrongLastSequence}}
+    set err
+} -result "wrong last sequence: 1" -cleanup {
+    execNatsCmd kv del $bucket -f
+}
+
+test key_value-update-3 "Throw BucketNotFound when calling update on non-existing bucket with -check_bucket set to true" -body {
+    if {![catch {
+        $kv update "non-existing-bucket" key1 1 value1 -check_bucket true
+    } err errOpts]} {
+        throw {TEST DidNotThrow} "Did not throw"
+    }
+    assert {[dict get $errOpts -errorcode] eq {NATS BucketNotFound}}
+    set err
+} -result "Bucket non-existing-bucket not found"
+
+test key_value-update-4 "Throw NoResponders/Timeout when calling update on non-existing bucket with -check_bucket set to false" -body {
+    if {![catch {
+        $kv update "non-existing-bucket" key1 1 value1 -check_bucket false
+    } err errOpts]} {
+        throw {TEST DidNotThrow} "Did not throw"
+    }
+    assert {[dict get $errOpts -errorcode] eq {NATS ErrNoResponders}}
+    set err
+} -result "No responders available for request"
+
+########### DELETE ###########
+
+test key_value-del-1 "Delete key" -setup {
+    execNatsCmd kv add $bucket
+    execNatsCmd kv put $bucket key1 value1
+} -body {
+    $kv del $bucket key1
+
+    catch { exec nats kv get $bucket key1 --raw } err errOpts
+    set err
+} -result {nats: error: nats: key not found} -cleanup {
+    execNatsCmd kv del $bucket -f
+}
+
+test key_value-del-2 "Delete bucket" -setup {
+    execNatsCmd kv add $bucket
+} -body {
+    $kv del $bucket 
+
+    catch { exec nats kv info $bucket } err errOpts
+    set err
+} -result {nats: error: nats: bucket not found}
+
+test key_value-del-3 "Throw BucketNotFound when calling del on key on non-existing bucket with -check_bucket set to true" -body {
+    if {![catch {
+        $kv del "non-existing-bucket" key1 -check_bucket true
+    } err errOpts]} {
+        throw {TEST DidNotThrow} "Did not throw"
+    }
+    assert {[dict get $errOpts -errorcode] eq {NATS BucketNotFound}}
+    set err
+} -result "Bucket non-existing-bucket not found"
+
+test key_value-del-4 "Throw NoResponders/Timeout when calling del on key on non-existing bucket with -check_bucket set to false" -body {
+    if {![catch {
+        $kv del "non-existing-bucket" key1 -check_bucket false
+    } err errOpts]} {
+        throw {TEST DidNotThrow} "Did not throw"
+    }
+    assert {[dict get $errOpts -errorcode] eq {NATS ErrNoResponders}}
+    set err
+} -result "No responders available for request"
+
+test key_value-del-5 "Throw BucketNotFound when calling del on non-existing bucket with -check_bucket set to false" -body {
+    if {![catch {
+        $kv del "non-existing-bucket" key1 -check_bucket false
+    } err errOpts]} {
+        throw {TEST DidNotThrow} "Did not throw"
+    }
+    assert {[dict get $errOpts -errorcode] eq {NATS ErrNoResponders}}
+    set err
+} -result "No responders available for request"
+
+########### PURGE ##########
+
+test key_value-purge-1 "Purge key" -setup {
+    execNatsCmd kv add $bucket --history 5
+    execNatsCmd kv put $bucket key1 value1
+    execNatsCmd kv put $bucket key1 value2
+    execNatsCmd kv put $bucket key1 value3
+} -body {
+    $kv purge $bucket key1
+
+    catch { exec nats kv get $bucket key1 --raw } err errOpts
+    set err
+} -result {nats: error: nats: key not found} -cleanup {
+    execNatsCmd kv del $bucket -f
+}
+
+test key_value-purge-2 "Throw BucketNotFound when calling purge on non-existing bucket with -check_bucket set to true" -body {
+    if {![catch {
+        $kv purge "non-existing-bucket" key1 -check_bucket true
+    } err errOpts]} {
+        throw {TEST DidNotThrow} "Did not throw"
+    }
+    assert {[dict get $errOpts -errorcode] eq {NATS BucketNotFound}}
+    set err
+} -result "Bucket non-existing-bucket not found"
+
+test key_value-purge-3 "Throw NoResponders/Timeout when calling purge on non-existing bucket with -check_bucket set to false" -body {
+    if {![catch {
+        $kv purge "non-existing-bucket" key1 -check_bucket false
+    } err errOpts]} {
+        throw {TEST DidNotThrow} "Did not throw"
+    }
+    assert {[dict get $errOpts -errorcode] eq {NATS ErrNoResponders}}
+    set err
+} -result "No responders available for request"
+
+########### REVERT ##########
+
+test key_value-revert-1 "Revert key" -setup {
+    execNatsCmd kv add $bucket --history 5
+    execNatsCmd kv put $bucket key1 value1
+    execNatsCmd kv put $bucket key1 value2
+    execNatsCmd kv put $bucket key1 value3
+} -body {
+    set new_revision [$kv revert $bucket key1 2]
+
+    set new_val [exec nats kv get $bucket key1 --raw]
+    assert {$new_val eq "value2"}
+
+    set new_revision
+} -result {4} -cleanup {
+    execNatsCmd kv del $bucket -f
+}
+
+test key_value-revert-2 "Throw BucketNotFound when calling revert on non-existing bucket" -body {
+    if {![catch {
+        $kv revert "non-existing-bucket" key1 1
+    } err errOpts]} {
+        throw {TEST DidNotThrow} "Did not throw"
+    }
+    assert {[dict get $errOpts -errorcode] eq {NATS BucketNotFound}}
+    set err
+} -result "Bucket non-existing-bucket not found"
+
+test key_value-revert-3 "Throw KeyNotFound when calling revert on non-existing key" -setup {
+    execNatsCmd kv add $bucket --history 5
+} -body {
+    if {![catch {
+        $kv revert $bucket non-existing-key 1
+    } err errOpts]} {
+        throw {TEST DidNotThrow} "Did not throw"
+    }
+    assert {[dict get $errOpts -errorcode] eq {NATS KeyNotFound}}
+    set err
+} -result "Key non-existing-key not found" -cleanup {
+    execNatsCmd kv del $bucket -f
+}
+
+########### OTHER ##########
+
+# this is "Mężny bądź, chroń pułk twój i sześć flag" (polish pangram) encoded in UTF-8
+set utf8_msg [encoding convertfrom utf-8 "\x4d\xc4\x99\xc5\xbc\x6e\x79\x20\x62\xc4\x85\x64\xc5\xba\x2c\x20\x63\x68\x72\x6f\xc5\x84\x20\x70\x75\xc5\x82\x6b\x20\x74\x77\xc3\xb3\x6a\x20\x69\x20\x73\x7a\x65\xc5\x9b\xc4\x87\x20\x66\x6c\x61\x67"]
+
+test key_value-others-1 "Check get/put encoding" -setup {
+    execNatsCmd kv add $bucket
+} -body {
+    # nats client is already running with "-utf8_convert true" flag - no need to restart it
+    # "puts" will probably print it wrong - in normal script it works fine, but with tests it is somehow messed up
+    $kv put $bucket key1 $utf8_msg
+    set res [$kv get $bucket key1]
+    dict get $res value
+} -result $utf8_msg
+
+$kv destroy
+$js destroy
+$conn destroy
+stopNats NATS_JS
+
+tcltest::cleanupTests

--- a/tests/key_value_mgmt.test
+++ b/tests/key_value_mgmt.test
@@ -1,0 +1,215 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and  limitations under the License.
+source test_utils.tcl
+
+set bucket MY_TEST_BUCKET
+startNats NATS_JS -js --store_dir [tcltest::temporaryDirectory];# start nats with Jet Stream
+
+set conn [nats::connection new]
+$conn configure -servers nats://localhost:4222
+$conn connect
+set js [$conn jet_stream]
+set kv [$js key_value]
+
+# cleanup if previous test has not cleaned up correctly
+set ls [execNatsCmd kv ls]
+if {$bucket in $ls} {
+    execNatsCmd kv del $bucket -f
+}
+
+########### DELETE ###########
+
+test key_value_mgmt-delete-1 "Delete bucket" -setup {
+    execNatsCmd kv add $bucket
+} -body {
+    $kv del $bucket 
+
+    catch { exec nats kv info $bucket } err errOpts
+    set err
+} -result {nats: error: nats: bucket not found} -cleanup {
+    # make sure it is removed
+    execNatsCmd kv add $bucket
+    execNatsCmd kv del $bucket -f
+}
+
+########### ADD ###########
+
+test key_value_mgmt-add-1 "Add bucket" -body {
+    set result [$kv add $bucket]
+
+    assert {[dict get $result did_create] eq "true"}
+    assert {[dict get $result config name] eq "KV_${bucket}"}
+    assert {[dict get $result config subjects] == {{$KV.MY_TEST_BUCKET.>}}}
+    assert {[dict get $result config storage] == "file"}
+    assert {[dict get $result config retention] == "limits"}
+    assert {[dict get $result config discard] == "new"}
+    assert {[dict get $result config max_msgs_per_subject] == 1}
+    assert {[dict get $result config num_replicas] == 1}
+    assert {[dict get $result config max_msgs] == -1}
+    assert {[dict get $result config max_msg_size] == -1}
+    assert {[dict get $result config max_bytes] == -1}
+    assert {[dict get $result config max_age] == 0}
+    assert {[dict get $result config duplicate_window] == 120000000000}
+    assert {[dict get $result config deny_delete] == "true"}
+    assert {[dict get $result config deny_purge] == "false"}
+    assert {[dict get $result config allow_rollup_hdrs] == "true"}
+
+    execNatsCmd kv info $bucket
+} -result "*Information for Key-Value Store Bucket $bucket*" -match glob -cleanup {
+    execNatsCmd kv del $bucket -f
+}
+
+test key_value_mgmt-add-2 "Add bucket with specified arguments" -body {
+    set result [$kv add $bucket -history 5 -storage memory -ttl 200000000000 -max_value_size 1000 -max_bucket_size 2000]
+
+    assert {[dict get $result did_create] eq "true"}
+    assert {[dict get $result config max_msgs_per_subject] == 5}
+    assert {[dict get $result config storage] == "memory"}
+    assert {[dict get $result config max_age] == 200000000000}
+    assert {[dict get $result config num_replicas] == 1}
+    assert {[dict get $result config max_msg_size] == 1000}
+    assert {[dict get $result config max_bytes] == 2000}
+
+    execNatsCmd kv info $bucket
+} -result "*Information for Key-Value Store Bucket $bucket*" -match glob -cleanup {
+    execNatsCmd kv del $bucket -f
+}
+
+test key_value_mgmt-add-3 "Throw when adding bucket with unknown arguments" -body {
+    if {![catch {
+        $kv add $bucket -unknown something
+    } err errOpts]} {
+        throw {TEST DidNotThrow} "Did not throw"
+    }
+    assert {[dict get $errOpts -errorcode] eq {NATS ErrInvalidArg}}
+    set err
+} -result {*Unknown option*} -match glob
+
+test key_value_mgmt-add-4 "Throw when adding bucket with wrong -history argument" -body {
+    if {![catch {
+        $kv add $bucket -history 0
+    } err errOpts]} {
+        throw {TEST DidNotThrow} "Did not throw"
+    }
+    assert {[dict get $errOpts -errorcode] eq {NATS ErrInvalidArg}}
+    set err
+} -result {history must be greater than 0}
+
+########### INFO ###########
+
+test key_value_mgmt-info-1 "Get bucket information" -setup {
+    execNatsCmd kv add $bucket
+    execNatsCmd kv put $bucket key1 value11
+    execNatsCmd kv put $bucket key1 value12
+    execNatsCmd kv put $bucket key2 value2
+} -body {
+    set response [$kv info $bucket]
+    set store_config [dict get $response store_config]
+    set store_state [dict get $response store_state]
+    set created [dict get $response created]
+
+    # "created" date is almost "now"
+    assert {abs([clock milliseconds] - $created) < 5000}
+
+    dict unset response store_config
+    dict unset response store_state
+    dict unset response created
+
+    # get the same info from NATS CLI and check that they are in line
+    set cli_info [json::json2dict [execNatsCmd stream info -j KV_${bucket}]]
+
+    # cli_info contains values in ns; convert them to ms
+    set cli_config [dict get $cli_info config]
+
+    # contains non-important information
+    dict unset store_config placement
+
+    nats::_ns2ms cli_config duplicate_window max_age
+    set cli_state [dict get $cli_info state]
+    assert {[dict get $store_state messages] == 2}
+    assert {[dict get $store_state num_subjects] == 2}
+
+    assert {[dict_in $store_config $cli_config]}
+    assert {[dict_in $store_state $cli_state]}
+    assert {[dict_in $response [dict create \
+        bucket $bucket \
+        stream KV_${bucket} \
+        storage file \
+        history 1 \
+        ttl 0 \
+        max_value_size -1 \
+        max_bucket_size -1 \
+        values_stored 2 \
+        bytes_stored 119 \
+        backing_store JetStream]]}
+} -cleanup {
+    execNatsCmd kv del $bucket -f
+}
+
+########### LIST ###########
+
+test key_value_mgmt-list-1 "List buckets with no actual buckets" -body {
+    $kv ls
+} -result ""
+
+test key_value_mgmt-list-2 "List buckets" -setup {
+    execNatsCmd kv add test1
+    execNatsCmd kv add test2
+} -body {
+    $kv ls 
+} -result "test1 test2" -cleanup {
+    execNatsCmd kv del test1 -f
+    execNatsCmd kv del test2 -f
+}
+
+########### KEYS ###########
+
+test key_value_mgmt-keys-1 "List keys" -setup {
+    execNatsCmd kv add $bucket
+    execNatsCmd kv put $bucket k1 val1
+    execNatsCmd kv put $bucket k2 val2
+} -body {
+    $kv keys $bucket 
+} -result "k1 k2" -cleanup {
+    execNatsCmd kv del $bucket -f
+}
+
+test key_value_mgmt-keys-2 "List keys for empty bucket returns empty array" -setup {
+    execNatsCmd kv add $bucket
+} -body {
+    $kv keys $bucket 
+} -result "" -cleanup {
+    execNatsCmd kv del $bucket -f
+}
+
+test key_value_mgmt-keys-3 "List keys for deleted entries should not return them" -setup {
+    execNatsCmd kv add $bucket
+    execNatsCmd kv put $bucket k1 val1
+    execNatsCmd kv del -f $bucket k1
+    execNatsCmd kv put $bucket k2 val2
+    execNatsCmd kv put $bucket k3 val1
+    execNatsCmd kv purge -f $bucket k3
+} -body {
+    $kv keys $bucket 
+} -result "k2" -cleanup {
+    execNatsCmd kv del -f $bucket
+}
+
+test key_value_mgmt-keys-4 "Throws when there is no bucket" -body {
+    if {![catch {
+        $kv keys non-existing-bucket
+    } err errOpts]} {
+        throw {TEST DidNotThrow} "Did not throw"
+    }
+    assert {[dict get $errOpts -errorcode] eq {NATS BucketNotFound}}
+    set err
+} -result {Bucket non-existing-bucket not found}
+
+# CLEANUP
+
+$kv destroy
+$js destroy
+$conn destroy
+stopNats NATS_JS
+
+tcltest::cleanupTests

--- a/tests/key_value_mirror.test
+++ b/tests/key_value_mirror.test
@@ -1,0 +1,273 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and  limitations under the License.
+source test_utils.tcl
+
+proc sortAndCheckEntries {entries} {
+    lmap entry $entries {
+        # "created" field exists and is almost the same as "now" 
+        assert {abs([clock milliseconds] - [dict get $entry created]) < 10000}
+
+        # omit "created" timestamp
+        set filtered_entry [dict filter $entry key value key bucket operation revision]
+        # sort by key name
+        lsort -stride 2 -index 0 $filtered_entry
+    }
+}
+
+startNats NATS_HUB -c ./conf/hub.conf --store_dir [file join [tcltest::temporaryDirectory] "store-hub"]
+startNats NATS_LEAF -c ./conf/leaf.conf --store_dir [file join [tcltest::temporaryDirectory] "store-leaf"]
+
+set hub_bucket MY_HUB_BUCKET
+set mirror_bucket MY_MIRROR_BUCKET
+set leaf_mirror_bucket MY_LEAF_MIRROR_BUCKET
+
+set hub_auth [list --user acc --password acc --server localhost:4222]
+set leaf_auth [list --user acc --password acc --server localhost:4111]
+
+# connect to hub server
+set conn_hub [nats::connection new "MyNatsToHub"]
+$conn_hub configure -servers nats://localhost:4222 -user acc -password acc
+$conn_hub connect
+set js_hub [$conn_hub jet_stream]
+set kv_hub [$js_hub key_value]
+
+# connect to leaf server
+set conn_leaf [nats::connection new "MyNatsToLeaf"]
+$conn_leaf configure -servers nats://localhost:4111 -user acc -password acc
+$conn_leaf connect
+set js_leaf [$conn_leaf jet_stream]
+set kv_leaf [$js_leaf key_value]
+
+# connect to leaf server but use "hub" domain
+set js_leaf_to_hub [$conn_leaf jet_stream -domain hub]
+set kv_leaf_to_hub [$js_leaf_to_hub key_value]
+
+
+# cleanup if previous test has not cleaned up correctly
+set ls [execNatsCmd kv ls {*}$hub_auth]
+if {$hub_bucket in $ls} {
+    execNatsCmd kv del $hub_bucket -f {*}$hub_auth
+}
+if {$mirror_bucket in $ls} {
+    execNatsCmd kv del $mirror_bucket -f {*}$hub_auth
+}
+
+set ls [execNatsCmd kv ls {*}$leaf_auth]
+if {$leaf_mirror_bucket in $ls} {
+    execNatsCmd kv del $leaf_mirror_bucket -f {*}$leaf_auth
+}
+
+########### DOMAIN ###########
+
+test key_value-domain-1 "Get values from hub bucket using leaf connection (from different domain)" -setup {
+    execNatsCmd kv add $hub_bucket {*}$hub_auth
+    execNatsCmd kv put $hub_bucket key1 value1 {*}$hub_auth
+} -body {
+    set entry [$kv_leaf_to_hub get $hub_bucket key1]
+    sortAndCheckEntries [list $entry]
+} -result [list [dict create \
+    bucket $hub_bucket \
+    key key1 \
+    operation PUT \
+    revision 1 \
+    value value1 \
+]] -cleanup {
+    execNatsCmd kv del $hub_bucket -f {*}$hub_auth
+}
+
+test key_value-domain-2 "Put values to hub bucket using leaf connection (from different domain)" -setup {
+    execNatsCmd kv add $hub_bucket {*}$hub_auth
+} -body {
+    $kv_leaf_to_hub put $hub_bucket key1 value1
+    set entry [$kv_hub get $hub_bucket key1]
+    sortAndCheckEntries [list $entry]
+} -result [list [dict create \
+    bucket $hub_bucket \
+    key key1 \
+    operation PUT \
+    revision 1 \
+    value value1 \
+]] -cleanup {
+    execNatsCmd kv del $hub_bucket -f {*}$hub_auth
+}
+
+test key_value_domain-3 "Get history of hub bucket using leaf connection (from different domain)" -setup {
+    execNatsCmd kv add $hub_bucket {*}$hub_auth
+    execNatsCmd kv put $hub_bucket key1 value1 {*}$hub_auth
+    execNatsCmd kv put $hub_bucket key2 value2 {*}$hub_auth
+} -body {
+    set entries [$kv_leaf_to_hub history $hub_bucket]
+    sortAndCheckEntries $entries
+} -result [list [dict create \
+    bucket $hub_bucket \
+    key key1 \
+    operation PUT \
+    revision 1 \
+    value value1 \
+] [dict create \
+    bucket $hub_bucket \
+    key key2 \
+    operation PUT \
+    revision 2 \
+    value value2 \
+]] -cleanup {
+    execNatsCmd kv del $hub_bucket -f {*}$hub_auth
+}
+
+test key_value_domain-4 "List hub buckets using leaf connection (from different domain)" -setup {
+    execNatsCmd kv add $hub_bucket {*}$hub_auth
+} -body {
+    $kv_leaf_to_hub ls
+} -result [list $hub_bucket] -cleanup {
+    execNatsCmd kv del $hub_bucket -f {*}$hub_auth
+}
+
+########### MIRROR IN THE SAME DOMAIN ###########
+
+test key_value-mirror-same-domain-1 "Create kv mirror in the same domain and check its messages" -setup {
+    execNatsCmd kv add $hub_bucket {*}$hub_auth
+    execNatsCmd kv put $hub_bucket key1 value1 {*}$hub_auth
+} -body {
+    $kv_hub add $mirror_bucket -mirror_name $hub_bucket
+    after 100; # wait in order to leave mirror kn some time to propagate messages from hub kv
+    set entry [$kv_hub get $mirror_bucket key1]
+    sortAndCheckEntries [list $entry]
+} -result [list [dict create \
+    bucket $hub_bucket \
+    key key1 \
+    operation PUT \
+    revision 1 \
+    value value1 \
+]] -cleanup {
+    execNatsCmd kv del $mirror_bucket -f {*}$hub_auth
+    execNatsCmd kv del $hub_bucket -f {*}$hub_auth
+}
+
+test key_value-mirror-same-domain-2 "Put message to mirror bucket and check if it is set in origin kv and mirror" -setup {
+    execNatsCmd kv add $hub_bucket {*}$hub_auth
+    execNatsCmd kv add $mirror_bucket --mirror $hub_bucket {*}$hub_auth
+} -body {
+    $kv_hub put $mirror_bucket key1 value1
+    set entry_hub [$kv_hub get $hub_bucket key1]
+    set entry_mirror [$kv_hub get $mirror_bucket key1]
+    assert {$entry_hub == $entry_mirror}
+    sortAndCheckEntries [list $entry_mirror]
+} -result [list [dict create \
+    bucket $hub_bucket \
+    key key1 \
+    operation PUT \
+    revision 1 \
+    value value1 \
+]] -cleanup {
+    execNatsCmd kv del $mirror_bucket -f {*}$hub_auth
+    execNatsCmd kv del $hub_bucket -f {*}$hub_auth
+}
+
+test key_value-mirror-same-domain-3 "Get history from mirror bucket" -setup {
+    execNatsCmd kv add $hub_bucket {*}$hub_auth
+    execNatsCmd kv put $hub_bucket key1 value1 {*}$hub_auth
+    execNatsCmd kv put $hub_bucket key2 value2 {*}$hub_auth
+    execNatsCmd kv add $mirror_bucket --mirror $hub_bucket {*}$hub_auth
+} -body {
+    set entries [$kv_hub history $mirror_bucket]
+    sortAndCheckEntries $entries
+} -result [list [dict create \
+    bucket $hub_bucket \
+    key key1 \
+    operation PUT \
+    revision 1 \
+    value value1 \
+] [dict create \
+    bucket $hub_bucket \
+    key key2 \
+    operation PUT \
+    revision 2 \
+    value value2 \
+]] -cleanup {
+    execNatsCmd kv del $mirror_bucket -f {*}$hub_auth
+    execNatsCmd kv del $hub_bucket -f {*}$hub_auth
+}
+
+########### MIRROR FROM OTHER DOMAIN ###########
+
+test key_value-mirror-different-domain-1 "Create kv mirror in different domain and check its messages" -setup {
+    execNatsCmd kv add $hub_bucket {*}$hub_auth
+    execNatsCmd kv put $hub_bucket key1 value1 {*}$hub_auth
+} -body {
+    $kv_leaf add $leaf_mirror_bucket -mirror_name $hub_bucket -mirror_domain "hub"
+    after 100; # wait in order to leave mirror kn some time to propagate messages from hub kv
+    set entry [$kv_leaf get $leaf_mirror_bucket key1]
+    sortAndCheckEntries [list $entry]
+} -result [list [dict create \
+    bucket $hub_bucket \
+    key key1 \
+    operation PUT \
+    revision 1 \
+    value value1 \
+]] -cleanup {
+    execNatsCmd kv del $leaf_mirror_bucket -f {*}$leaf_auth
+    execNatsCmd kv del $hub_bucket -f {*}$hub_auth
+}
+
+test key_value-mirror-different-domain-2 "Put message to mirror bucket and check if it is set in origin kv (hub domain) and mirror" -setup {
+    execNatsCmd kv add $hub_bucket {*}$hub_auth
+    execNatsCmd kv add $leaf_mirror_bucket --mirror $hub_bucket --mirror-domain "hub" {*}$leaf_auth
+} -body {
+    $kv_leaf put $leaf_mirror_bucket key1 value1
+    set entry_hub [$kv_hub get $hub_bucket key1]
+    set entry_mirror [$kv_leaf get $leaf_mirror_bucket key1]
+    assert {$entry_hub == $entry_mirror}
+    sortAndCheckEntries [list $entry_mirror]
+} -result [list [dict create \
+    bucket $hub_bucket \
+    key key1 \
+    operation PUT \
+    revision 1 \
+    value value1 \
+]] -cleanup {
+    execNatsCmd kv del $leaf_mirror_bucket -f {*}$leaf_auth
+    execNatsCmd kv del $hub_bucket -f {*}$hub_auth
+}
+
+test key_value-mirror-different-domain-3 "Get history from mirror bucket" -setup {
+    execNatsCmd kv add $hub_bucket {*}$hub_auth
+    execNatsCmd kv put $hub_bucket key1 value1 {*}$hub_auth
+    execNatsCmd kv put $hub_bucket key2 value2 {*}$hub_auth
+    execNatsCmd kv add $leaf_mirror_bucket --mirror $hub_bucket --mirror-domain "hub" {*}$leaf_auth
+} -body {
+    set entries [$kv_leaf history $leaf_mirror_bucket]
+    sortAndCheckEntries $entries
+} -result [list [dict create \
+    bucket $hub_bucket \
+    key key1 \
+    operation PUT \
+    revision 1 \
+    value value1 \
+] [dict create \
+    bucket $hub_bucket \
+    key key2 \
+    operation PUT \
+    revision 2 \
+    value value2 \
+]] -cleanup {
+    execNatsCmd kv del $leaf_mirror_bucket -f {*}$leaf_auth
+    execNatsCmd kv del $hub_bucket -f {*}$hub_auth
+}
+
+########### CLEANUP ###########
+
+$kv_leaf_to_hub destroy
+$js_leaf_to_hub destroy
+
+$kv_leaf destroy
+$js_leaf destroy
+$conn_leaf destroy
+
+$kv_hub destroy
+$js_hub destroy
+$conn_hub destroy
+
+stopNats NATS_LEAF
+stopNats NATS_HUB
+
+tcltest::cleanupTests

--- a/tests/key_value_watchers.test
+++ b/tests/key_value_watchers.test
@@ -1,0 +1,471 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and  limitations under the License.
+source test_utils.tcl
+
+proc sortAndCheckEntries {entries} {
+    lmap entry $entries {
+        # "created" field exists and is almost the same as "now" 
+        assert {abs([clock milliseconds] - [dict get $entry created]) < 10000}
+
+        # omit "created" timestamp
+        set filtered_entry [dict filter $entry key value key bucket operation revision]
+        # sort by key name
+        lsort -stride 2 -index 0 $filtered_entry
+    }
+}
+
+proc sortAndCheckWatchCallbacks {callbacks} {
+    lmap callback_args $callbacks {
+        set status [lindex $callback_args 0]
+        set entry [lindex $callback_args 1]
+        if {$status eq ""} {
+            # it is normal message - "created" field exists and is almost the same as "now"
+            assert {abs([clock milliseconds] - [dict get $entry created]) < 10000}
+
+            # omit "created" timestamp if it exists
+            set entry [dict filter $entry key value key bucket operation revision]
+            set entry [lsort -stride 2 -index 0 $entry]
+        }
+
+        # sort by key name
+        list $status $entry
+    }
+}
+
+proc exampleCallback {status msg} {
+    lappend ::received [list $status $msg]
+    if {[llength $::received] == $::expected_count} {
+        set ::complete true
+    }
+}
+
+set bucket MY_TEST_BUCKET
+startNats NATS_JS -js --store_dir [tcltest::temporaryDirectory];# start nats with Jet Stream
+
+set conn [nats::connection new]
+$conn configure -servers nats://localhost:4222
+$conn connect
+set js [$conn jet_stream]
+set kv [$js key_value]
+
+# cleanup if previous test has not cleaned up correctly
+set ls [execNatsCmd kv ls]
+if {$bucket in $ls} {
+    execNatsCmd kv del $bucket -f
+}
+
+########## HISTORY ##########
+
+test key_value_watchers-history-1 "Get history for specific key" -setup {
+    execNatsCmd kv add $bucket --history=10
+    execNatsCmd kv put $bucket key1 value1_1
+    execNatsCmd kv put $bucket key1 value1_2
+} -body {
+    set entries [$kv history $bucket key1]
+
+    sortAndCheckEntries $entries
+} -result [list \
+    [list bucket $bucket key key1 operation PUT revision 1 value value1_1] \
+    [list bucket $bucket key key1 operation PUT revision 2 value value1_2] \
+] -cleanup {
+    execNatsCmd kv del $bucket -f
+}
+
+test key_value_watchers-history-2 "Get history for all bucket" -setup {
+    execNatsCmd kv add $bucket --history=10
+    execNatsCmd kv put $bucket key1 value1_1
+    execNatsCmd kv put $bucket key1 value1_2
+    execNatsCmd kv put $bucket key2 value2_1
+    execNatsCmd kv put $bucket key2 value2_2
+    execNatsCmd kv put $bucket key1 value1_3
+    execNatsCmd kv put $bucket key3 value3_1
+} -body {
+    set entries [$kv history $bucket]
+
+    sortAndCheckEntries $entries
+} -result [list \
+    [list bucket $bucket key key1 operation PUT revision 1 value value1_1] \
+    [list bucket $bucket key key1 operation PUT revision 2 value value1_2] \
+    [list bucket $bucket key key2 operation PUT revision 3 value value2_1] \
+    [list bucket $bucket key key2 operation PUT revision 4 value value2_2] \
+    [list bucket $bucket key key1 operation PUT revision 5 value value1_3] \
+    [list bucket $bucket key key3 operation PUT revision 6 value value3_1] \
+] -cleanup {
+    execNatsCmd kv del $bucket -f
+}
+
+test key_value_watchers-history-3 "Get history for specific key with delete operation" -setup {
+    execNatsCmd kv add $bucket --history=10
+    execNatsCmd kv put $bucket key1 value1_1
+    execNatsCmd kv put $bucket key1 value1_2
+    execNatsCmd kv del $bucket key1 -f
+    execNatsCmd kv put $bucket key1 value1_3
+} -body {
+    set entries [$kv history $bucket key1]
+
+    sortAndCheckEntries $entries
+} -result [list \
+    [list bucket $bucket key key1 operation PUT revision 1 value value1_1] \
+    [list bucket $bucket key key1 operation PUT revision 2 value value1_2] \
+    [list bucket $bucket key key1 operation DEL revision 3 value {}] \
+    [list bucket $bucket key key1 operation PUT revision 4 value value1_3] \
+] -cleanup {
+    execNatsCmd kv del $bucket -f
+}
+
+test key_value_watchers-history-4 "Get history for specific key with purge operation" -setup {
+    execNatsCmd kv add $bucket --history=10
+    execNatsCmd kv put $bucket key1 value1_1
+    execNatsCmd kv purge -f $bucket key1
+    execNatsCmd kv put $bucket key1 value1_2
+} -body {
+    set value [$kv history $bucket key1]
+
+    lmap entry $value {
+        # omit "created" timestamp
+        set filtered_entry [dict filter $entry key value key bucket operation revision]
+        # sort by key name
+        lsort -stride 2 -index 0 $filtered_entry
+    }
+} -result [list \
+    [list bucket $bucket key key1 operation PURGE revision 2 value {}] \
+    [list bucket $bucket key key1 operation PUT revision 3 value value1_2] \
+] -cleanup {
+    execNatsCmd kv del $bucket -f
+}
+
+test key_value_watchers-history-5 "Returns immediately when there is no values" -setup {
+    execNatsCmd kv add $bucket --history=10
+} -body {
+    $kv history $bucket key1
+} -result {} -cleanup {
+    execNatsCmd kv del $bucket -f
+}
+
+test key_value_watchers-history-6 "Throws when there is no bucket" -body {
+    if {![catch {
+        $kv history non-existing-bucket
+    } err errOpts]} {
+        throw {TEST DidNotThrow} "Did not throw"
+    }
+    assert {[dict get $errOpts -errorcode] eq {NATS BucketNotFound}}
+    set err
+} -result {Bucket non-existing-bucket not found}
+
+########## WATCH ##########
+
+test key_value_watchers-watch-1 "Watch simple key" -setup {
+    set ::received [list]
+    unset -nocomplain ::complete
+    execNatsCmd kv add $bucket
+    execNatsCmd kv put $bucket key1 value1_1
+    execNatsCmd kv put $bucket key1 value1_2
+} -body {
+    set ::expected_count 2
+    set watchID [$kv watch $bucket key1 -callback exampleCallback]
+    after 5000 [list set ::complete true] ;# timeout
+
+    vwait ::complete
+    after cancel [list set ::complete true]
+    if {[llength $::received] != $::expected_count} {
+        throw {TEST NotEnoughCalls} "Callback was not received expected number of times. Expected: $::expected_count, got: [llength $::received] ($::received)"
+    }
+
+    sortAndCheckWatchCallbacks $::received
+} -result [list \
+    [list {} [list bucket $bucket key key1 operation PUT revision 2 value value1_2]] \
+    [list end_of_initial_data {}] \
+] -cleanup {
+    $kv unwatch $watchID
+    execNatsCmd kv del $bucket -f
+}
+
+test key_value_watchers-watch-2 "Watch multiple keys" -setup {
+    set ::received [list]
+    unset -nocomplain ::complete
+    execNatsCmd kv add $bucket
+    execNatsCmd kv put $bucket key1 value1_1
+    execNatsCmd kv put $bucket key1 value1_2
+    execNatsCmd kv put $bucket key2 value2_1
+    execNatsCmd kv put $bucket key3 value3_1
+} -body {
+    set ::expected_count 4
+    set watchID [$kv watch $bucket -callback exampleCallback]
+    after 5000 [list set ::complete true] ;# timeout
+
+    vwait ::complete
+    after cancel [list set ::complete true]
+    if {[llength $::received] != $::expected_count} {
+        throw {TEST NotEnoughCalls} "Callback was not received expected number of times. Expected: $::expected_count, got: [llength $::received] ($::received)"
+    }
+
+    sortAndCheckWatchCallbacks $::received
+} -result [list \
+    [list {} [list bucket $bucket key key1 operation PUT revision 2 value value1_2]] \
+    [list {} [list bucket $bucket key key2 operation PUT revision 3 value value2_1]] \
+    [list {} [list bucket $bucket key key3 operation PUT revision 4 value value3_1]] \
+    [list end_of_initial_data {}] \
+] -cleanup {
+    $kv unwatch $watchID
+    execNatsCmd kv del $bucket -f
+}
+
+test key_value_watchers-watch-3 "Watch key with history" -setup {
+    set ::received [list]
+    unset -nocomplain ::complete
+    execNatsCmd kv add $bucket --history=10
+    execNatsCmd kv put $bucket key1 value1_1
+    execNatsCmd kv put $bucket key1 value1_2
+    execNatsCmd kv put $bucket key1 value1_3
+} -body {
+    set ::expected_count 4
+    set watchID [$kv watch $bucket key1 -callback exampleCallback -include_history true]
+    after 5000 [list set ::complete true] ;# timeout
+
+    vwait ::complete
+    after cancel [list set ::complete true]
+    if {[llength $::received] != $::expected_count} {
+        throw {TEST NotEnoughCalls} "Callback was not received expected number of times. Expected: $::expected_count, got: [llength $::received] ($::received)"
+    }
+
+    sortAndCheckWatchCallbacks $::received
+} -result [list \
+    [list {} [list bucket $bucket key key1 operation PUT revision 1 value value1_1]] \
+    [list {} [list bucket $bucket key key1 operation PUT revision 2 value value1_2]] \
+    [list {} [list bucket $bucket key key1 operation PUT revision 3 value value1_3]] \
+    [list end_of_initial_data {}] \
+] -cleanup {
+    $kv unwatch $watchID
+    execNatsCmd kv del $bucket -f
+}
+
+test key_value_watchers-watch-4 "Watch key with history, purge and delete operations" -setup {
+    set ::received [list]
+    unset -nocomplain ::complete
+    execNatsCmd kv add $bucket --history=10
+    execNatsCmd kv put $bucket key1 value1_1
+    execNatsCmd kv purge -f $bucket key1
+    execNatsCmd kv put $bucket key1 value1_2
+    execNatsCmd kv put $bucket key1 value1_3
+    execNatsCmd kv del -f $bucket key1
+    execNatsCmd kv put $bucket key1 value1_4
+} -body {
+    set ::expected_count 6
+    set watchID [$kv watch $bucket key1 -callback exampleCallback -include_history true]
+    after 5000 [list set ::complete true] ;# timeout
+
+    vwait ::complete
+    after cancel [list set ::complete true]
+    if {[llength $::received] < $::expected_count} {
+        throw {TEST NotEnoughCalls} "Callback was not received expected number of times. Expected: $::expected_count, got: [llength $::received] ($::received)"
+    }
+
+    sortAndCheckWatchCallbacks $::received
+} -result [list \
+    [list {} [list bucket $bucket key key1 operation PURGE revision 2 value {}]] \
+    [list {} [list bucket $bucket key key1 operation PUT revision 3 value value1_2]] \
+    [list {} [list bucket $bucket key key1 operation PUT revision 4 value value1_3]] \
+    [list {} [list bucket $bucket key key1 operation DEL revision 5 value {}]] \
+    [list {} [list bucket $bucket key key1 operation PUT revision 6 value value1_4]] \
+    [list end_of_initial_data {}] \
+] -cleanup {
+    $kv unwatch $watchID
+    execNatsCmd kv del $bucket -f
+}
+
+test key_value_watchers-watch-5 "Watch key with headers only and history, with purge and delete operations" -setup {
+    set ::received [list]
+    unset -nocomplain ::complete
+    execNatsCmd kv add $bucket --history=10
+    execNatsCmd kv put $bucket key1 value1_1
+    execNatsCmd kv purge -f $bucket key1
+    execNatsCmd kv put $bucket key1 value1_2
+    execNatsCmd kv del -f $bucket key1
+    execNatsCmd kv put $bucket key1 value1_3
+} -body {
+    set ::expected_count 5
+    set watchID [$kv watch $bucket key1 -callback exampleCallback -headers_only true -include_history true]
+    after 5000 [list set ::complete true] ;# timeout
+
+    vwait ::complete
+    after cancel [list set ::complete true]
+    if {[llength $::received] < $::expected_count} {
+        throw {TEST NotEnoughCalls} "Callback was not received expected number of times. Expected: $::expected_count, got: [llength $::received] ($::received)"
+    }
+
+    sortAndCheckWatchCallbacks $::received
+} -result [list \
+    [list {} [list bucket $bucket key key1 operation PURGE revision 2 value {}]] \
+    [list {} [list bucket $bucket key key1 operation PUT revision 3 value {}]] \
+    [list {} [list bucket $bucket key key1 operation DEL revision 4 value {}]] \
+    [list {} [list bucket $bucket key key1 operation PUT revision 5 value {}]] \
+    [list end_of_initial_data {}] \
+] -cleanup {
+    $kv unwatch $watchID
+    execNatsCmd kv del $bucket -f
+}
+
+test key_value_watchers-watch-6 "Watch key with history and ignore deletes" -setup {
+    set ::received [list]
+    unset -nocomplain ::complete
+    execNatsCmd kv add $bucket --history=10
+    execNatsCmd kv put $bucket key1 value1_1
+    execNatsCmd kv purge -f $bucket key1
+    execNatsCmd kv put $bucket key1 value1_2
+    execNatsCmd kv del -f $bucket key1
+    execNatsCmd kv put $bucket key1 value1_3
+} -body {
+    set ::expected_count 3
+    set watchID [$kv watch $bucket key1 -callback exampleCallback -ignore_deletes true -include_history true]
+    after 5000 [list set ::complete true] ;# timeout
+
+    vwait ::complete
+    after cancel [list set ::complete true]
+    if {[llength $::received] < $::expected_count} {
+        throw {TEST NotEnoughCalls} "Callback was not received expected number of times. Expected: $::expected_count, got: [llength $::received] ($::received)"
+    }
+
+    sortAndCheckWatchCallbacks $::received
+} -result [list \
+    [list {} [list bucket $bucket key key1 operation PUT revision 3 value value1_2]] \
+    [list {} [list bucket $bucket key key1 operation PUT revision 5 value value1_3]] \
+    [list end_of_initial_data {}] \
+] -cleanup {
+    $kv unwatch $watchID
+    execNatsCmd kv del $bucket -f
+}
+
+test key_value_watchers-watch-7 "Watch key with updates only" -setup {
+    set ::received [list]
+    unset -nocomplain ::complete
+    execNatsCmd kv add $bucket --history=10
+    execNatsCmd kv put $bucket key1 value1_1
+} -body {
+    set ::expected_count 2
+    set watchID [$kv watch $bucket key1 -callback exampleCallback -updates_only true -idle_heartbeat 1000]
+    after 3000 [list execNatsCmd kv put $bucket key1 value1_2] ;# do it after first heartbeat and end of initial data
+    after 10000 [list set ::complete true] ;# timeout
+
+    vwait ::complete
+    after cancel [list set ::complete true]
+    if {[llength $::received] < $::expected_count} {
+        throw {TEST NotEnoughCalls} "Callback was not received expected number of times. Expected: $::expected_count, got: [llength $::received] ($::received)"
+    }
+
+    sortAndCheckWatchCallbacks $::received
+} -result [list \
+    [list end_of_initial_data {}] \
+    [list {} [list bucket $bucket key key1 operation PUT revision 2 value value1_2]] \
+] -cleanup {
+    $kv unwatch $watchID
+    execNatsCmd kv del $bucket -f
+}
+
+test key_value_watchers-watch-8 "Watching key should continue after server restart" -setup {
+    set ::received [list]
+    unset -nocomplain ::complete
+    execNatsCmd kv add $bucket --history=10
+} -body {
+    set ::expected_count 2
+    set watchID [$kv watch $bucket key1 -callback exampleCallback -updates_only true -idle_heartbeat 1000]
+    
+    # restart server - it would re-create consumer automatically
+    after 2000 [list stopNats NATS_JS]
+    after 2500 [list startNats NATS_JS -js --store_dir [tcltest::temporaryDirectory];]
+
+    after 4000 [list execNatsCmd kv put $bucket key1 value1_1]
+    after 10000 [list set ::complete true] ;# timeout
+
+    vwait ::complete
+    after cancel [list set ::complete true]
+    if {[llength $::received] < $::expected_count} {
+        throw {TEST NotEnoughCalls} "Callback was not received expected number of times. Expected: $::expected_count, got: [llength $::received] ($::received)"
+    }
+
+    sortAndCheckWatchCallbacks $::received
+} -result [list \
+    [list end_of_initial_data {}] \
+    [list {} [list bucket $bucket key key1 operation PUT revision 1 value value1_1]] \
+] -cleanup {
+    $kv unwatch $watchID
+    execNatsCmd kv del $bucket -f
+}
+
+test key_value_watchers-watch-9 "Watching key should continue and user should bo notified after server has been down for some time (more than 3 heartbeats)" -setup {
+    set ::received [list]
+    unset -nocomplain ::complete
+    execNatsCmd kv add $bucket --history=10
+} -body {
+    set ::expected_count 4 ;# if server has been down for long time user should be notified
+    set watchID [$kv watch $bucket key1 -callback exampleCallback -updates_only true -idle_heartbeat 500]
+    
+    after 2000 [list stopNats NATS_JS]
+    after 5000 [list startNats NATS_JS -js --store_dir [tcltest::temporaryDirectory];]
+
+    after 7000 [list execNatsCmd kv put $bucket key1 value1_1]
+    after 10000 [list set ::complete true] ;# timeout
+
+    vwait ::complete
+    after cancel [list set ::complete true]
+    if {[llength $::received] < $::expected_count} {
+        throw {TEST NotEnoughCalls} "Callback was not received expected number of times. Expected: $::expected_count, got: [llength $::received] ($::received)"
+    }
+
+    sortAndCheckWatchCallbacks $::received
+} -result [list \
+    [list end_of_initial_data {}] \
+    [list error "Server disconnected"] \
+    [list ok {}] \
+    [list {} [list bucket $bucket key key1 operation PUT revision 1 value value1_1]] \
+] -cleanup {
+    $kv unwatch $watchID
+    execNatsCmd kv del $bucket -f
+}
+
+test key_value_watchers-watch-10 "Watching key should continue and consumer should be re-created after it has been somehow removed" -setup {
+    set ::received [list]
+    unset -nocomplain ::complete
+    execNatsCmd kv add $bucket --history=10
+} -body {
+    set ::expected_count 2
+    set watchID [$kv watch $bucket key1 -callback exampleCallback -updates_only true -idle_heartbeat 500]
+
+    set consumers [$js consumer_names KV_${bucket}]
+    # there should be only one consumer for this bucket
+    assert {[llength $consumers] == 1}
+    set first_consumer [lindex $consumers 0]
+
+    after 1000 [list $js delete_consumer KV_${bucket} $first_consumer]
+
+    # consumer should be re-created at this point
+    after 5000 [list execNatsCmd kv put $bucket key1 value1_1]
+    after 10000 [list set ::complete true] ;# timeout
+
+    vwait ::complete
+    after cancel [list set ::complete true]
+
+    set consumers [$js consumer_names KV_${bucket}]
+    # there should still be only one consumer that is different than previous
+    assert {[llength $consumers] == 1}
+    set seconds_consumer [lindex $consumers 0]
+    assert {$seconds_consumer != $first_consumer}
+
+    if {[llength $::received] < $::expected_count} {
+        throw {TEST NotEnoughCalls} "Callback was not received expected number of times. Expected: $::expected_count, got: [llength $::received] ($::received)"
+    }
+
+    sortAndCheckWatchCallbacks $::received
+} -result [list \
+    [list end_of_initial_data {}] \
+    [list {} [list bucket $bucket key key1 operation PUT revision 1 value value1_1]] \
+] -cleanup {
+    $kv unwatch $watchID
+    execNatsCmd kv del $bucket -f
+}
+
+$kv destroy
+$js destroy
+$conn destroy
+stopNats NATS_JS
+
+tcltest::cleanupTests

--- a/tests/test_utils.tcl
+++ b/tests/test_utils.tcl
@@ -206,7 +206,8 @@ namespace eval test_utils {
     
     proc execNatsCmd {args} {
         set output [exec -ignorestderr nats {*}$args]
-        log::info "Executed: nats $args"
+        # turn off logging - key-value tests use it heavily
+        # log::info "Executed: nats $args"
         return $output
     }
     


### PR DESCRIPTION
Hi!

Here is huge pull request with full support for key-value store based on JetStreams.
There is a lot of code, but core nats and jet_streams are almost untouched - beside some changes to `_dict2json` which now enables `objects` to be formatted - it was necessary in order to enable `mirror` and `sources` options in `add_stream` method (which were necessary for `kv` to enable mirroring).
Most of this code was based on behaviour and API of `nats-cli` client with some small changes. I also looked at ADR which are linked in source code. There is also documentation written with examples as well as a lot of tests.
Hope you find it interesting :) 

Kindest regards
